### PR TITLE
Add try catch to handle local storage errors

### DIFF
--- a/src/js/controllers/chatController.js
+++ b/src/js/controllers/chatController.js
@@ -7,6 +7,7 @@ var ViewController = require('view-controller');
 var endpoint = require('../endpoint');
 var vent = require('../vent');
 var faye = require('../faye');
+var storage = require('../utils/localStorage');
 
 var ChatView = require('../views/chatView');
 var HeaderView = require('../views/headerView');
@@ -328,17 +329,17 @@ module.exports = ViewController.extend({
         var key = this._getLatestReadTimeKey();
         var latestReadTs;
         try {
-            latestReadTs = parseInt(localStorage.getItem(key) || 0);
+            latestReadTs = parseInt(storage.getItem(key) || 0);
         }
         catch (e) {
-        latestReadTs = 0;
+            latestReadTs = 0;
         }
         return latestReadTs;
     },
 
     _setLatestReadTime: function(ts) {
         var key = this._getLatestReadTimeKey();
-        localStorage.setItem(key, ts);
+        storage.setItem(key, ts);
     },
 
     _updateUnread: function() {
@@ -356,7 +357,7 @@ module.exports = ViewController.extend({
 
     clearUnread: function() {
         var key = this._getLatestReadTimeKey();
-        localStorage.removeItem(key);
+        storage.removeItem(key);
     },
 
     resetUnread: function() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -12,6 +12,7 @@ var AppUser = require('./models/appUser');
 var ChatController = require('./controllers/chatController');
 var endpoint = require('./endpoint');
 var api = require('./utils/api');
+var storage = require('./utils/localStorage');
 
 var SK_STORAGE = 'sk_deviceid';
 
@@ -187,10 +188,10 @@ _.extend(Smooch.prototype, Backbone.Events, {
         var deviceId;
 
         // get device ID first from local storage, then cookie. Otherwise generate new one
-        deviceId = localStorage.getItem(SK_STORAGE) ||
+        deviceId = storage.getItem(SK_STORAGE) ||
             uuid.v4().replace(/-/g, '');
 
-        localStorage.setItem(SK_STORAGE, deviceId);
+        storage.setItem(SK_STORAGE, deviceId);
 
         return deviceId;
     },

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,7 +5,7 @@ var Backbone = require('backbone');
 var _ = require('underscore');
 var $ = require('jquery');
 var uuid = require('uuid');
-var urljoin = require('url-join');
+var urljoin = require('urljoin');
 var bindAll = require('lodash.bindall');
 
 var AppUser = require('./models/appUser');

--- a/src/js/utils/localStorage.js
+++ b/src/js/utils/localStorage.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var memoryStorage = {};
+
+function setItem(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    }
+    catch (err) {
+        console.warn('Smooch local storage warn: localStorage not available; falling back on memory storage');
+        memoryStorage[key] = value;
+    }
+}
+
+function getItem(key) {
+    return localStorage.getItem(key) || memoryStorage[key];
+}
+
+function removeItem(key) {
+    localStorage.removeItem(key);
+    delete memoryStorage[key];
+}
+
+module.exports = {
+    setItem: setItem,
+    getItem: getItem,
+    removeItem: removeItem
+};

--- a/test/specs/main.spec.js
+++ b/test/specs/main.spec.js
@@ -8,6 +8,7 @@ var ClientScenario = require('../scenarios/clientScenario');
 var userData = require('../data/user');
 var endpoint = require('../../src/js/endpoint');
 var api = require('../../src/js/utils/api');
+var storage = require('../../src/js/utils/localStorage');
 
 var SK_STORAGE = 'sk_deviceid';
 
@@ -98,7 +99,7 @@ describe('Main', function() {
                 appToken: appToken,
                 userId: userId
             }).then(function() {
-                localStorage.getItem(SK_STORAGE).should.exist;
+                storage.getItem(SK_STORAGE).should.exist;
             });
         });
 
@@ -200,16 +201,16 @@ describe('Main', function() {
 
     describe('#destroy', function() {
         beforeEach(function() {
-            localStorage.setItem(SK_STORAGE, 'test');
+            storage.setItem(SK_STORAGE, 'test');
             Smooch.destroy();
         });
 
         afterEach(function() {
-            localStorage.setItem(SK_STORAGE, undefined);
+            storage.setItem(SK_STORAGE, undefined);
         });
 
         it('should not remove the device id from local storage', function() {
-            expect(localStorage.getItem(SK_STORAGE)).to.exist;
+            expect(storage.getItem(SK_STORAGE)).to.exist;
 
         });
 
@@ -265,15 +266,15 @@ describe('Main', function() {
     describe('#_cleanState', function() {
 
         beforeEach(function() {
-            localStorage.setItem(SK_STORAGE, 'test');
+            storage.setItem(SK_STORAGE, 'test');
         });
 
         afterEach(function() {
-            localStorage.setItem(SK_STORAGE, undefined);
+            storage.setItem(SK_STORAGE, undefined);
         });
 
         it('should not remove the device id from local storage', function() {
-            expect(localStorage.getItem(SK_STORAGE)).to.exist;
+            expect(storage.getItem(SK_STORAGE)).to.exist;
         });
 
         it('should clear endpoint values but keep the app token', function() {


### PR DESCRIPTION
@lemieux @jugarrit @jpjoyal @spasiu 

Fixes the issue crashing Safari in private mode since the localStorage is disabled. It is showing up in `window`, throws when we try to `setItem`.