### PR TITLE
Add support for link in brackets

### DIFF
--- a/src/js/utils/html.js
+++ b/src/js/utils/html.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 function autolink(text, options) {
     options || (options = {});
 
-    var pattern = /(^|[\s\n]|<br\/?>)((?:[a-z]*):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
+    var pattern = /(^|[\s\n\[]|<br\/?>)((?:[a-z]*):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
     var linkAttributes = _.map(options, function(value, key) {
         return key + '="' + value + '"';
     }).join(' ');


### PR DESCRIPTION
Links we get from the `node-html-to-text` we use to parse integrations messages returns this syntax `check this link [https://link.com]` which isn't handle by the current regex. I've added the possibility to the regex to have a `[` at the beginning.

![image](https://cloud.githubusercontent.com/assets/1034297/11048862/3a60a7a6-8708-11e5-8daf-29586f86d5b2.png)
![image](https://cloud.githubusercontent.com/assets/1034297/11048876/4e49e32c-8708-11e5-8bf6-b0cf53b4a42c.png)
