### PR TITLE
Add support to update user attributes on login

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -290,7 +290,7 @@ module.exports = function(grunt) {
     grunt.registerTask('versionBump', function() {
         var semver = require('semver');
         var VERSION_REGEXP = /(\bversion[\'\"]?\s*[:=]\s*[\'\"])([\da-z\.-]+)([\'\"])/i;
-        var files = ['package.json', 'bower.json', 'src/js/main.js'];
+        var files = ['package.json', 'bower.json'];
         var fullVersion = grunt.option('version');
         var versionType = grunt.option('versionType');
         var globalVersion;

--- a/README.md
+++ b/README.md
@@ -130,13 +130,19 @@ Closes the conversation widget
 Smooch.close();
 ```
 
-#### login(userId [, jwt])
+#### login(userId [, jwt] [, attributes])
 Logs a user in the widget, retrieving the conversation that user already had on other browsers and/or devices. This will destroy and reinitialize the widget with the user's data. Note that you don't need to call this after `init`, it's already done internally. This returns a promise that resolves when the widget is ready again.
 ```
 Smooch.login('some-id');
 
 // in case you are using the jwt authentication
 Smooch.login('some-id', 'some-jwt');
+
+// in case you want to update user attributes at the same time
+Smooch.login('some-id', { email: 'my@new-email.com'});
+
+// in case you want to update user attributes at the same time and use jwt
+Smooch.login('some-id', 'some-jwt', { email: 'my@new-email.com'});
 
 ```
 
@@ -176,7 +182,7 @@ Smooch.updateUser({
 ```
 
 #### track(eventName)
-Tracks an event for the current user. 
+Tracks an event for the current user.
 
 ```javascript
 Smooch.track('item-in-cart');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,6 +14,8 @@ var endpoint = require('./endpoint');
 var api = require('./utils/api');
 var storage = require('./utils/localStorage');
 
+var packageInfo = require('../../package.json');
+
 var SK_STORAGE = 'sk_deviceid';
 
 // appends the compile stylesheet to the HEAD
@@ -34,7 +36,7 @@ var Smooch = function() {
 };
 
 _.extend(Smooch.prototype, Backbone.Events, {
-    VERSION: '2.0.5',
+    VERSION: packageInfo.version,
 
     defaultText: {
         headerText: 'How can we help?',
@@ -80,19 +82,10 @@ _.extend(Smooch.prototype, Backbone.Events, {
                     'Missing capability: css-transform'));
         }
 
-
         this.ready = false;
-        options = options || {};
 
-        // if the email was passed at init, it can't be changed through the web widget UI
-        var readOnlyEmail = !_.isEmpty(options.email);
-        var emailCaptureEnabled = options.emailCaptureEnabled && !readOnlyEmail;
-        var uiText = _.extend({}, this.defaultText, options.customText);
-
-        this.options = _.defaults(options, {
-            emailCaptureEnabled: emailCaptureEnabled,
-            readOnlyEmail: readOnlyEmail,
-            uiText: uiText
+        this.options = _.defaults(options || {}, {
+            uiText: _.extend({}, this.defaultText, options.customText)
         });
 
         if (typeof options === 'string') {
@@ -116,10 +109,17 @@ _.extend(Smooch.prototype, Backbone.Events, {
 
         endpoint.sdkVersion = this.VERSION;
 
-        return this.login(options.userId, options.jwt);
+        return this.login(options.userId, options.jwt, _.pick(options, AppUser.EDITABLE_PROPERTIES));
     },
 
-    login: function(userId, jwt) {
+    login: function(userId, jwt, attributes) {
+        if (arguments.length === 2 && _.isObject(jwt)) {
+            attributes = jwt;
+            jwt = undefined;
+        } else if (arguments.length < 3) {
+            attributes = {};
+        }
+
         // clear unread for anonymous
         if (!this.user.isNew() && userId && !this.user.get('userId')) {
             // the previous user had no userId and it's switching to one with an id
@@ -153,6 +153,15 @@ _.extend(Smooch.prototype, Backbone.Events, {
             endpoint.jwt = jwt;
         }
 
+        // if the email was passed at init, it can't be changed through the web widget UI
+        var readOnlyEmail = !_.isEmpty(attributes.email);
+        var emailCaptureEnabled = this.options.emailCaptureEnabled && !readOnlyEmail;
+
+        _.extend(this.options, {
+            readOnlyEmail: readOnlyEmail,
+            emailCaptureEnabled: emailCaptureEnabled
+        });
+
         return api.call({
             url: 'v1/init',
             method: 'POST',
@@ -165,7 +174,7 @@ _.extend(Smooch.prototype, Backbone.Events, {
 
                 endpoint.appUserId = this.user.id;
 
-                return this.user.save(_.pick(this.options, AppUser.EDITABLE_PROPERTIES), {
+                return this.user.save(_.pick(attributes, AppUser.EDITABLE_PROPERTIES), {
                     wait: true
                 });
             }).bind(this))

--- a/test/specs/main.spec.js
+++ b/test/specs/main.spec.js
@@ -137,7 +137,7 @@ describe('Main', function() {
             });
         });
 
-        it('should accept user properties via init', function() {
+        it('should pass user props to login', function() {
             Smooch.destroy();
             var email = 'some@email.com';
             var givenName = 'Some';
@@ -157,6 +157,14 @@ describe('Main', function() {
                 signedUpAt: signedUpAt,
                 properties: properties
             }).then(function() {
+                loginSpy.args[0][2].should.deep.equal({
+                    email: email,
+                    givenName: givenName,
+                    surname: surname,
+                    signedUpAt: signedUpAt,
+                    properties: properties
+                });
+
                 Smooch.user.get('email').should.equal(email);
                 Smooch.user.get('givenName').should.equal(givenName);
                 Smooch.user.get('surname').should.equal(surname);
@@ -203,7 +211,36 @@ describe('Main', function() {
                 endpoint.userId.should.equal(newUserId);
                 endpoint.jwt.should.equal(newJwt);
             });
+        });
 
+        it('should user props on login', function() {
+            var email = 'some@email.com';
+            var givenName = 'Some';
+            var surname = 'Name';
+            var signedUpAt = new Date();
+            var properties = {
+                favoriteFood: 'prizza',
+                isAwesome: true,
+                level: 9001
+            };
+            
+            var newUserId = 'new_user_id';
+            var newJwt = 'new_jwt';
+
+            return Smooch.login(newUserId, newJwt, {
+                email: email,
+                givenName: givenName,
+                surname: surname,
+                signedUpAt: signedUpAt,
+                properties: properties
+            }).then(function() {
+                Smooch.user.get('email').should.equal(email);
+                Smooch.user.get('givenName').should.equal(givenName);
+                Smooch.user.get('surname').should.equal(surname);
+                (typeof Smooch.user.get('signedUpAt')).should.equal('object');
+                Smooch.user.get('signedUpAt').getTime().should.equal(signedUpAt.getTime());
+                Smooch.user.get('properties').should.deep.equal(properties);
+            });
         });
     });
 


### PR DESCRIPTION
Currently, we are only able to update the user on init. This makes possible to do it on login too. It also fixes a bug where some state was kept after logout and was not reset on login.

I also made the package pull the version from package.json instead of doing an awkward string replace operation on build.

@alavers @dannytranlx @jugarrit 