### PR TITLE
Remove user change listener on chatView

### DIFF
--- a/src/js/views/chatView.js
+++ b/src/js/views/chatView.js
@@ -13,10 +13,6 @@ module.exports = Marionette.LayoutView.extend({
         'focus @ui.wrapper': 'focus'
     },
 
-    modelEvents: {
-        'change': 'open'
-    },
-
     ui: {
         wrapper: '#sk-wrapper'
     },


### PR DESCRIPTION
This caused the widget to open whenever the user changed (on updateUser for instance). I'm not even sure why it was there in the first place... if we want to do something like that, we should do it only on first appMaker message or something. I'll just remove it for now.

This fixes #140.