### PR TITLE
Release 2.0.8

### DIFF
--- a/release_notes/v2.0.8.md
+++ b/release_notes/v2.0.8.md
@@ -1,0 +1,2 @@
+# Changes
+- The widget wanted attention when a user was updated. We told it to stay calm, now it only opens when we tell it to. (#140)


### PR DESCRIPTION
# Changes
- The widget wanted attention when a user was updated. We told it to stay calm, now it only opens when we tell it to. (#140)