### PR TITLE
Service url support for dev page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
         /* global Smooch: false */
 
         window.SmoochOptions = {
+            serviceUrl: 'ROOT_URL',
             appToken: 'APP_TOKEN',
             givenName: 'GIVEN_NAME',
             surname: 'SURNAME',


### PR DESCRIPTION
The webpack transition made the service Url unusable in the dev environment.

This brings it back. We were replacing it directly in the bundle in dev, but now.. there's in no bundle because webpack is serving it in memory.

@dannytranlx @alavers 