### PR TITLE
Escape HTML before rendering messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "karma-phantomjs-shim": "^1.0.0",
     "karma-sinon-chai": "^0.3.0",
     "karma-sourcemap-loader": "^0.3.6",
-    "karma-spec-reporter-2": "^0.2.0",
+    "karma-spec-reporter": "0.0.23",
     "karma-webpack": "^1.7.0",
     "less": "^2.5.3",
     "less-loader": "^2.2.2",

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { ActionComponent } from 'components/action';
 
-import { createMarkup, autolink } from 'utils/html';
+import { createMarkup, autolink, escapeHtml } from 'utils/html';
 
 export class MessageComponent extends Component {
     render() {
@@ -13,7 +13,7 @@ export class MessageComponent extends Component {
         });
 
         const isAppUser = this.props.role === 'appUser';
-        
+
         let avatar = isAppUser ? null : (
             <img className="sk-msg-avatar" src={ this.props.avatarUrl } />
             );
@@ -23,7 +23,8 @@ export class MessageComponent extends Component {
                 return;
             }
 
-            let innerHtml = createMarkup(autolink(item, {
+
+            let innerHtml = createMarkup(autolink(escapeHtml(item), {
                 target: '_blank'
             }));
 

--- a/src/js/utils/html.js
+++ b/src/js/utils/html.js
@@ -17,5 +17,10 @@ export function autolink(text, options) {
     linkAttributes && (linkAttributes += ' ');
 
     return text.replace(pattern, `$1<a ${linkAttributes}href="$2">$2</a>`);
+}
 
+export function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(text));
+    return div.innerHTML;
 }

--- a/test/specs/utils/html.spec.js
+++ b/test/specs/utils/html.spec.js
@@ -1,4 +1,4 @@
-import { createMarkup, autolink } from 'utils/html';
+import { createMarkup, autolink, escapeHtml } from 'utils/html';
 
 describe('createMarkup', () => {
     it('should wrap the give value', () => {
@@ -30,5 +30,11 @@ describe('autolink', () => {
         let transformedValue = autolink(value, options);
 
         transformedValue.should.eq(expectedValue);
+    });
+});
+
+describe('escapeHtml', () => {
+    it('should escape html', () => {
+        escapeHtml('<strong>Escape me!</strong>').should.eq('&lt;strong&gt;Escape me!&lt;/strong&gt;');
     });
 });


### PR DESCRIPTION
Html wasn't escaped allowing the message to be messed up if html was in the content.