### PR TITLE
Non-persistent and non-increasing badge count fix

### DIFF
--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -105,19 +105,25 @@ export function updateReadTimestamp(timestamp = Date.now()) {
 }
 
 export function handleConversationUpdated() {
-    return getConversation()
-        .then((response) => {
-            return connectFaye().then(() => {
-                return response;
+    let subscription = store.getState().faye.subscription;
+    
+    if (!subscription) {
+        return getConversation()
+            .then((response) => {
+                return connectFaye().then(() => {
+                    return response;
+                })
             })
-        })
-        .then((response) => {
-            let conversationLength = response.conversation.messages.length;
-            let lastMessage = conversationLength > 0 && response.conversation.messages[conversationLength - 1];
-            if (lastMessage && lastMessage.role !== 'appUser' && getReadTimestamp() === 0) {
-                updateReadTimestamp(lastMessage.received);
-            }
+            .then((response) => {
+                let conversationLength = response.conversation.messages.length;
+                let lastMessage = conversationLength > 0 && response.conversation.messages[conversationLength - 1];
+                if (lastMessage && lastMessage.role !== 'appUser' && getReadTimestamp() === 0) {
+                    updateReadTimestamp(lastMessage.received);
+                }
 
-            return response;
-        });
+                return response;
+            });
+    }
+
+    return Promise.resolve();
 }

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -45,12 +45,7 @@ export function sendMessage(text) {
 
     if (store.getState().user.conversationStarted) {
         return promise
-            .then(() => {
-                const fayeSubscription = store.getState().faye.subscription;
-                if (!fayeSubscription) {
-                    return connectFaye();
-                }
-            })
+            .then(connectFaye)
             .then(sendFn);
     }
 
@@ -64,12 +59,6 @@ export function sendMessage(text) {
 export function getConversation() {
     const user = store.getState().user;
     return core().conversations.get(user._id).then((response) => {
-        let conversationLength = response.conversation.messages.length;
-        let lastMessage = conversationLength > 0 && response.conversation.messages[conversationLength - 1];
-        if (lastMessage && lastMessage.role !== 'appUser' && getReadTimestamp() === 0) {
-            updateReadTimestamp(lastMessage.received);
-        }
-
         store.dispatch(setConversation(response.conversation));
         return response;
     });
@@ -113,4 +102,22 @@ export function updateReadTimestamp(timestamp = Date.now()) {
 
     storage.setItem(storageKey, timestamp);
     store.dispatch(updateReadTimestampAction(timestamp));
+}
+
+export function handleConversationUpdated() {
+    return getConversation()
+        .then((response) => {
+            return connectFaye().then(() => {
+                return response;
+            })
+        })
+        .then((response) => {
+            let conversationLength = response.conversation.messages.length;
+            let lastMessage = conversationLength > 0 && response.conversation.messages[conversationLength - 1];
+            if (lastMessage && lastMessage.role !== 'appUser' && getReadTimestamp() === 0) {
+                updateReadTimestamp(lastMessage.received);
+            }
+
+            return response;
+        });
 }

--- a/src/js/services/user-service.js
+++ b/src/js/services/user-service.js
@@ -2,7 +2,7 @@ import deepEqual from 'deep-equal';
 import { store } from 'stores/app-store';
 import { core } from 'services/core';
 import { setUser } from 'actions/user-actions';
-import { getConversation, connectFaye } from 'services/conversation-service';
+import { handleConversationUpdated } from 'services/conversation-service';
 
 let waitForSave = false;
 const waitDelay = 5000; // ms
@@ -57,11 +57,9 @@ export function trackEvent(eventName, userProps) {
     const user = store.getState().user;
     return core().appUsers.trackEvent(user._id, eventName, userProps).then((response) => {
         if (response.conversationUpdated) {
-            return getConversation()
-                .then(connectFaye)
-                .then(() => {
-                    return response;
-                });
+            return handleConversationUpdated().then(() => {
+                return response;
+            });
         }
 
         return response;

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -16,7 +16,7 @@ import { reset } from 'actions/common-actions';
 import { login } from 'services/auth-service';
 import { getAccount } from 'services/stripe-service';
 import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, immediateUpdate as immediateUpdateUser } from 'services/user-service';
-import { getConversation, sendMessage, connectFaye, disconnectFaye, getReadTimestamp } from 'services/conversation-service';
+import { getConversation, sendMessage, connectFaye, disconnectFaye, getReadTimestamp, handleConversationUpdated } from 'services/conversation-service';
 
 import { Observable, observeStore } from 'utils/events';
 import { storage } from 'utils/storage';
@@ -204,10 +204,7 @@ export class Smooch extends Observable {
     updateUser(props) {
         return updateUser(props).then((response) => {
             if (response.appUser.conversationStarted) {
-                return getConversation().then((conversationResponse) => {
-                    store.dispatch(setConversation(conversationResponse.conversation));
-                    return connectFaye();
-                }).then(() => {
+                return handleConversationUpdated().then(() => {
                     return response;
                 });
             }

--- a/src/js/utils/faye.js
+++ b/src/js/utils/faye.js
@@ -3,7 +3,7 @@ import urljoin from 'urljoin';
 
 import { store } from 'stores/app-store';
 import { addMessage } from 'actions/conversation-actions';
-import { updateReadTimestamp } from 'services/conversation-service';
+import { updateReadTimestamp, getReadTimestamp } from 'services/conversation-service';
 
 export function initFaye() {
     const state = store.getState();
@@ -30,6 +30,9 @@ export function initFaye() {
         });
 
         return faye.subscribe('/conversations/' + state.conversation._id, (message) => {
+            if (message && message.role !== 'appUser' && getReadTimestamp() === 0) {
+                updateReadTimestamp(message.received);
+            }
             store.dispatch(addMessage(message));
         });
     }

--- a/src/js/utils/faye.js
+++ b/src/js/utils/faye.js
@@ -30,7 +30,6 @@ export function initFaye() {
         });
 
         return faye.subscribe('/conversations/' + state.conversation._id, (message) => {
-            updateReadTimestamp(message.received);
             store.dispatch(addMessage(message));
         });
     }

--- a/test/specs/services/user-service.spec.js
+++ b/test/specs/services/user-service.spec.js
@@ -123,17 +123,14 @@ describe('User service', () => {
                     conversationUpdated: true
                 });
 
-                sandbox.stub(conversationService, 'getConversation');
-                sandbox.stub(conversationService, 'connectFaye');
-                conversationService.getConversation.resolves();
-                conversationService.connectFaye.resolves();
+                sandbox.stub(conversationService, 'handleConversationUpdated');
+                conversationService.handleConversationUpdated.resolves({});
             });
 
             it('should call getConversation and connectFaye', () => {
                 return userService.trackEvent('event', 'props').then(() => {
                     coreMock.appUsers.trackEvent.should.have.been.calledWith('1', 'event', 'props');
-                    conversationService.getConversation.should.have.been.calledOnce;
-                    conversationService.connectFaye.should.have.been.calledOnce;
+                    conversationService.handleConversationUpdated.should.have.been.calledOnce;
                 });
             });
         });
@@ -144,17 +141,14 @@ describe('User service', () => {
                     conversationUpdated: false
                 });
 
-                sandbox.stub(conversationService, 'getConversation');
-                sandbox.stub(conversationService, 'connectFaye');
-                conversationService.getConversation.resolves();
-                conversationService.connectFaye.resolves();
+                sandbox.stub(conversationService, 'handleConversationUpdated');
+                conversationService.handleConversationUpdated.resolves({});
             });
 
             it('should call getConversation and connectFaye', () => {
                 return userService.trackEvent('event', 'props').then(() => {
                     coreMock.appUsers.trackEvent.should.have.been.calledWith('1', 'event', 'props');
-                    conversationService.getConversation.should.not.have.been.called;
-                    conversationService.connectFaye.should.not.have.been.called;
+                    conversationService.handleConversationUpdated.should.not.have.been.called;
                 });
             });
         });

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -228,45 +228,20 @@ describe('Smooch', () => {
     describe('Track event', () => {
         beforeEach(() => {
             mockedStore = mockStore(sandbox, defaultState);
-        });
-
-        describe('conversation updated', () => {
-            beforeEach(() => {
-                trackEventStub = sandbox.stub(userService, 'trackEvent');
-                trackEventStub.resolves({
-                    conversationUpdated: true
-                });
-            });
-
-
-            it('should call trackEvent and connectFaye', () => {
-                const props = {
-                    email: 'some@email.com'
-                };
-
-                return smooch.track('some-event', props).then(() => {
-                    trackEventStub.should.have.been.calledWith('some-event', props);
-                });
+            trackEventStub = sandbox.stub(userService, 'trackEvent');
+            trackEventStub.resolves({
+                conversationUpdated: true
             });
         });
 
-        describe('conversation not updated', () => {
-            beforeEach(() => {
-                trackEventStub = sandbox.stub(userService, 'trackEvent');
-                trackEventStub.resolves({
-                    conversationUpdated: false
-                });
-            });
 
+        it('should call trackEvent', () => {
+            const props = {
+                email: 'some@email.com'
+            };
 
-            it('should call trackEvent and connectFaye', () => {
-                const props = {
-                    email: 'some@email.com'
-                };
-
-                return smooch.track('some-event', props).then(() => {
-                    trackEventStub.should.have.been.calledWith('some-event', props);
-                });
+            return smooch.track('some-event', props).then(() => {
+                trackEventStub.should.have.been.calledWith('some-event', props);
             });
         });
     });
@@ -293,11 +268,8 @@ describe('Smooch', () => {
 
             updateUserStub = sandbox.stub(userService, 'update');
 
-            getConversationStub = sandbox.stub(conversationService, 'getConversation');
-            getConversationStub.resolves({});
-
-            connectFayeStub = sandbox.stub(conversationService, 'connectFaye');
-            connectFayeStub.resolves({});
+            sandbox.stub(conversationService, 'handleConversationUpdated');
+            conversationService.handleConversationUpdated.resolves({});
         });
 
         describe('conversation started', () => {
@@ -309,7 +281,7 @@ describe('Smooch', () => {
                 });
             });
 
-            it('should get the conversation and connect faye', () => {
+            it('should call handleConversationUpdated', () => {
                 return smooch.updateUser({
                     email: 'update@me.com'
                 }).then(() => {
@@ -317,8 +289,7 @@ describe('Smooch', () => {
                         email: 'update@me.com'
                     });
 
-                    getConversationStub.should.have.been.calledOnce;
-                    connectFayeStub.should.have.been.calledOnce;
+                    conversationService.handleConversationUpdated.should.have.been.calledOnce;
                 });
             });
         });
@@ -332,7 +303,7 @@ describe('Smooch', () => {
                 });
             });
 
-            it('should not get the conversation and connect faye', () => {
+            it('should not handleConversationUpdated', () => {
                 return smooch.updateUser({
                     email: 'update@me.com'
                 }).then(() => {
@@ -340,8 +311,7 @@ describe('Smooch', () => {
                         email: 'update@me.com'
                     });
 
-                    getConversationStub.should.not.have.been.calledOnce;
-                    connectFayeStub.should.not.have.been.calledOnce;
+                    conversationService.handleConversationUpdated.should.not.have.been.calledOnce;
                 });
             });
         });


### PR DESCRIPTION
Whenever the conversation was updated and the timestamp was at 0, it always took the last message as the unread timestamp. On startup, the ts was at 0 so it was set to the last message `received` props after fetching the conversation. I normalized a bit how we check for a lastRead update.

Also, every message coming through faye was setting the unread ts to that message ts which ended up having a count of 1 all the time.

@alavers @mspensieri 
