### PR TITLE
Prevent double insertion of babel-polyfill

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
     var LICENSE = fs.readFileSync('LICENSE', 'utf8');
 
     var entry = {
-        smooch: ['babel-polyfill', './src/js/utils/polyfills', './src/js/main']
+        smooch: ['./src/js/utils/polyfills', './src/js/main']
     };
 
     var loaders = {

--- a/src/js/utils/polyfills.js
+++ b/src/js/utils/polyfills.js
@@ -1,3 +1,7 @@
+if (!global._babelPolyfill) {
+    require('babel-polyfill');
+}
+
 (function() {
     // setPrototypeOf Polyfill for =< IE10
 


### PR DESCRIPTION
This should prevent problems with site that already have it.

This would need to be tests on IE at least since that the browser that required the most it in the first place.

@mspensieri @dannytranlx