### PR TITLE
Cleanup unused animations classes

### DIFF
--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -19,7 +19,7 @@ export class WidgetComponent extends Component {
         // It was never opened nor closed. `sk-appear` and `sk-close` expect to be in one or the other state
         // for their animations. The animation can go from undefined to `sk-appear`, `sk-appear` to `sk-close`, and
         // `sk-close` to `sk-appear`. If it starts with `sk-close`, it starts by being opened and animates to close state.
-        let className = typeof this.props.appState.widgetOpened === 'undefined' ? '' :
+        let className = this.props.appState.widgetOpened === null ? '' :
             this.props.appState.widgetOpened ? 'sk-appear' : 'sk-close';
 
         let notification = this.props.appState.errorNotificationMessage ?

--- a/src/js/reducers/app-state-reducer.js
+++ b/src/js/reducers/app-state-reducer.js
@@ -4,7 +4,7 @@ import { RESET } from 'actions/common-actions';
 const INITIAL_STATE = {
     settingsVisible: false,
     settingsNotificationVisible: false,
-    widgetOpened: undefined,
+    widgetOpened: null,
     settingsEnabled: true,
     readOnlyEmail: false,
     serverURL: 'https://api.smooch.io/',

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -25,14 +25,12 @@ import { waitForPage } from 'utils/dom';
 function renderWidget() {
     const el = document.createElement('div');
     el.setAttribute('id', 'sk-holder');
-    el.className = 'sk-noanimation';
 
     const Root = (process.env.NODE_ENV === 'production' ? require('./root-prod') : require('./root-dev')).Root;
     render(<Root store={ store } />, el);
 
     waitForPage().then(() => {
         document.body.appendChild(el);
-        setTimeout(() => el.className = '', 200);
     });
 
 

--- a/src/js/utils/html.js
+++ b/src/js/utils/html.js
@@ -4,7 +4,6 @@ export function createMarkup(html) {
     };
 }
 
-
 export function autolink(text, options) {
     options || (options = {});
 

--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -1,10 +1,3 @@
-&.sk-noanimation {
-    .sk-appear, .sk-close {
-        -webkit-animation: none;
-                animation: none;
-    }
-}
-
 .sk-appear {
     bottom: 0;
 
@@ -16,6 +9,7 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 }
+
 .sk-appear #sk-handle {
     -webkit-transform: rotate(270deg);
             transform: rotate(270deg);
@@ -44,22 +38,7 @@
         bottom: 0;
     }
 }
-@-webkit-keyframes sk-rotate-frames {
-    0% {
-        -webkit-transform: rotate(270deg);
-    }
-    100% {
-        -webkit-transform: rotate(90deg);
-    }
-}
-@keyframes sk-rotate-frames {
-    0% {
-        transform: rotate(270deg);
-    }
-    100% {
-        transform: rotate(90deg);
-    }
-}
+
 .sk-close {
     bottom: @widget-close-bottom;
 
@@ -87,37 +66,7 @@
         bottom: @widget-close-bottom;
     }
 }
-.sk-close #sk-handle {
-    -webkit-transform: rotate(90deg);
-            transform: rotate(90deg);
-    -webkit-animation: sk-rotate-close-frames .7s cubic-bezier(.62, .28, .23, .99);
-            animation: sk-rotate-close-frames .7s cubic-bezier(.62, .28, .23, .99);
-    -webkit-animation-delay: .0s;
-            animation-delay: .0s;
 
-    -webkit-animation-fill-mode: forwards;
-            animation-fill-mode: forwards;
-}
-@-webkit-keyframes sk-rotate-close-frames {
-    0% {
-        -webkit-transform: rotate(90deg);
-    }
-    100% {
-        -webkit-transform: rotate(270deg);
-    }
-}
-@keyframes sk-rotate-close-frames {
-    0% {
-        transform: rotate(90deg);
-    }
-    100% {
-        transform: rotate(270deg);
-    }
-}
-.sk-noanimation {
-    -webkit-animation: none;
-            animation: none;
-}
 .sk-noselect {
     -webkit-user-select: none;
        -moz-user-select: none;


### PR DESCRIPTION
Seems like these items weren't cleaned up in the rewrite. I also made a change to the default value of `widgetOpened` in the reducer (null instead of undefined).

@mspensieri @dannytranlx 