### PR TITLE
Events for open and close states

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Smooch.logout();
 ```
 
 #### destroy()
-Destroys the widget and makes it disappear. The widget has to be reinitialized with `init`  to be working again because it also clears up the app token from the widget.
+Destroys the widget and makes it disappear. The widget has to be reinitialized with `init`  to be working again because it also clears up the app token from the widget. It will also unbind all listeners you might have with `Smooch.on`.
 
 ```
 Smooch.destroy();
@@ -198,6 +198,8 @@ Smooch.track('item-in-cart');
 
 ### Events
 If you want to make sure your events are triggered, try to bind them before calling `Smooch.init`.
+
+To bind an event, use `Smooch.on(<event name>, <handler>);`. To unbind events, you can either call `Smooch.off(<event name>, handler)` to remove one specific handler, call `Smooch.off(<event name>)` to remove all handlers for an event, or call `Smooch.off()` to unbind all handlers.
 
 #### ready
 ```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ Closes the conversation widget (noop when embedded)
 Smooch.close();
 ```
 
+#### isOpened()
+Tells if the widget is currently opened or closed.
+
+```javascript
+Smooch.isOpened();
+```
+
 #### login(userId [, jwt] [, attributes])
 Logs a user in the widget, retrieving the conversation that user already had on other browsers and/or devices. This will destroy and reinitialize the widget with the user's data. Note that you don't need to call this after `init`, it's already done internally. This returns a promise that resolves when the widget is ready again.
 ```
@@ -233,6 +240,22 @@ Smooch.on('message:sent', function(message) {
 // This event triggers when a message was added to the conversation
 Smooch.on('message', function(message) {
     console.log('a message was added to the conversation', message);
+});
+```
+
+#### widget:opened
+```
+// This event triggers when the widget is opened
+Smooch.on('widget:opened', function() {
+    console.log('Widget is opened!');
+});
+```
+
+#### widget:closed
+```
+// This event triggers when the widget is closed
+Smooch.on('widget:closed', function() {
+    console.log('Widget is closed!');
 });
 ```
 

--- a/src/embedded.html
+++ b/src/embedded.html
@@ -26,14 +26,6 @@
     Smooch.on('message', function(message) {
       console.log('Message received', message);
     });
-
-    Smooch.on('widget:opened', function(message) {
-      console.log('Widget opened');
-    });
-
-    Smooch.on('widget:closed', function(message) {
-      console.log('Widget opened');
-    });
   </script>
 
   <style type="text/css">
@@ -240,17 +232,8 @@
 
       destroyButton.addEventListener('click', function() {
         Smooch.destroy();
-
         Smooch.on('message', function(message) {
           console.log('Message received', message);
-        });
-
-        Smooch.on('widget:opened', function(message) {
-          console.log('Widget opened');
-        });
-
-        Smooch.on('widget:closed', function(message) {
-          console.log('Widget opened');
         });
       });
 

--- a/src/embedded.html
+++ b/src/embedded.html
@@ -26,6 +26,14 @@
     Smooch.on('message', function(message) {
       console.log('Message received', message);
     });
+
+    Smooch.on('widget:opened', function(message) {
+      console.log('Widget opened');
+    });
+
+    Smooch.on('widget:closed', function(message) {
+      console.log('Widget opened');
+    });
   </script>
 
   <style type="text/css">
@@ -232,6 +240,18 @@
 
       destroyButton.addEventListener('click', function() {
         Smooch.destroy();
+
+        Smooch.on('message', function(message) {
+          console.log('Message received', message);
+        });
+
+        Smooch.on('widget:opened', function(message) {
+          console.log('Widget opened');
+        });
+
+        Smooch.on('widget:closed', function(message) {
+          console.log('Widget opened');
+        });
       });
 
       openButton.addEventListener('click', function() {

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,14 @@
           console.log('Message received', message);
         });
 
+        Smooch.on('widget:opened', function(message) {
+          console.log('Widget opened');
+        });
+
+        Smooch.on('widget:closed', function(message) {
+          console.log('Widget opened');
+        });
+
         Smooch.init(SmoochOptions);
     </script>
 
@@ -215,6 +223,18 @@
 
             destroyButton.addEventListener('click', function() {
                 Smooch.destroy();
+
+                Smooch.on('message', function(message) {
+                  console.log('Message received', message);
+                });
+
+                Smooch.on('widget:opened', function(message) {
+                  console.log('Widget opened');
+                });
+
+                Smooch.on('widget:closed', function(message) {
+                  console.log('Widget opened');
+                });
             });
 
             openButton.addEventListener('click', function() {

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
         });
 
         Smooch.on('widget:closed', function(message) {
-          console.log('Widget opened');
+          console.log('Widget closed');
         });
 
         Smooch.init(SmoochOptions);
@@ -233,7 +233,7 @@
                 });
 
                 Smooch.on('widget:closed', function(message) {
-                  console.log('Widget opened');
+                  console.log('Widget closed');
                 });
             });
 

--- a/src/js/components/header.jsx
+++ b/src/js/components/header.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { toggleWidget, showSettings, hideSettings } from 'actions/app-state-actions';
+import { toggleWidget } from 'services/app-service';
+import { showSettings, hideSettings } from 'actions/app-state-actions';
 
 export class HeaderComponent extends Component {
     constructor(props) {
@@ -70,7 +71,7 @@ export class HeaderComponent extends Component {
                              </div>;
 
         return (
-            <div id={ settingsVisible ? 'sk-settings-header' : 'sk-header' } onClick={ !embedded && this.actions.toggleWidget }>
+            <div id={ settingsVisible ? 'sk-settings-header' : 'sk-header' } onClick={ !embedded && toggleWidget }>
                 { settingsButton }
                 { backButton }
                 { settingsVisible ? settingsText : headerText }
@@ -92,7 +93,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            toggleWidget,
             showSettings,
             hideSettings
         }, dispatch)

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -18,7 +18,7 @@ export class WidgetComponent extends Component {
         let className;
 
         if (this.props.appState.embedded) {
-            className = 'sk-embedded'
+            className = 'sk-embedded';
         } else {
             // We check for `undefined` explicitely because it means the widget is in it's default state
             // It was never opened nor closed. `sk-appear` and `sk-close` expect to be in one or the other state

--- a/src/js/services/app-service.js
+++ b/src/js/services/app-service.js
@@ -23,12 +23,10 @@ export function closeWidget() {
 export function toggleWidget() {
     let {embedded, widgetOpened} = store.getState().appState;
     if (!embedded) {
-        store.dispatch(AppStateActions.toggleWidget());
-        
         if (widgetOpened) {
-            observable.trigger('widget:closed');
+            closeWidget();
         } else {
-            observable.trigger('widget:opened');
+            openWidget();
         }
     }
 }

--- a/src/js/services/app-service.js
+++ b/src/js/services/app-service.js
@@ -1,0 +1,34 @@
+import { store } from 'stores/app-store';
+import * as AppStateActions from 'actions/app-state-actions';
+import { observable } from 'utils/events';
+
+
+export function openWidget() {
+    let {embedded} = store.getState().appState;
+    if (!embedded) {
+        store.dispatch(AppStateActions.openWidget());
+        observable.trigger('widget:opened');
+    }
+}
+
+export function closeWidget() {
+    let {embedded} = store.getState().appState;
+    if (!embedded) {
+        store.dispatch(AppStateActions.closeWidget());
+        observable.trigger('widget:closed');
+    }
+}
+
+
+export function toggleWidget() {
+    let {embedded, widgetOpened} = store.getState().appState;
+    if (!embedded) {
+        store.dispatch(AppStateActions.toggleWidget());
+        
+        if (widgetOpened) {
+            observable.trigger('widget:closed');
+        } else {
+            observable.trigger('widget:opened');
+        }
+    }
+}

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -13,6 +13,7 @@ import { setConversation, resetConversation } from 'actions/conversation-actions
 import * as AppStateActions from 'actions/app-state-actions';
 import { reset } from 'actions/common-actions';
 
+import { openWidget, closeWidget } from 'services/app-service';
 import { login } from 'services/auth-service';
 import { getAccount } from 'services/stripe-service';
 import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, immediateUpdate as immediateUpdateUser } from 'services/user-service';
@@ -236,20 +237,15 @@ export class Smooch {
         delete this.appToken;
         delete this._container;
         observable.trigger('destroy');
+        observable.off();
     }
 
     open() {
-        let {embedded} = store.getState().appState;
-        if (!embedded) {
-            store.dispatch(AppStateActions.openWidget());
-        }
+        openWidget();
     }
 
     close() {
-        let {embedded} = store.getState().appState;
-        if (!embedded) {
-            store.dispatch(AppStateActions.closeWidget());
-        }
+        closeWidget();
     }
 
     render(container) {

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -248,6 +248,10 @@ export class Smooch {
         closeWidget();
     }
 
+    isOpened() {
+        return !!store.getState().appState.widgetOpened;
+    }
+
     render(container) {
         this._container = container;
         return renderWidget(container);

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -18,14 +18,20 @@ export class Observable {
     off(event, handler) {
         let map = this[listeners];
         if (map.has(event)) {
-            map.get(event).delete(handler);
+            if (handler) {
+                map.get(event).delete(handler);
+            } else {
+                map.get(event).clear();
+            }
+        } else {
+            map.clear();
         }
     }
 
     trigger(event, options) {
         let map = this[listeners];
         if (map.has(event)) {
-            map.get(event).forEach(handler => handler(options));
+            map.get(event).forEach((handler) => handler(options));
         }
     }
 }

--- a/test/specs/components/header.spec.jsx
+++ b/test/specs/components/header.spec.jsx
@@ -4,13 +4,17 @@ import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
 import { scryRenderedDOMComponentsWithId, findRenderedDOMComponentsWithId } from 'test/utils/react';
-
+import * as appService from 'services/app-service';
 import { HeaderComponent } from 'components/header.jsx';
 
 const sandbox = sinon.sandbox.create();
 let props;
 
 describe('Header', () => {
+    beforeEach(() => {
+        sandbox.stub(appService, 'toggleWidget');
+    });
+
     afterEach(() => {
         sandbox.restore();
     });
@@ -33,8 +37,7 @@ describe('Header', () => {
                     },
                     actions: {
                         showSettings: sandbox.spy(),
-                        hideSettings: sandbox.spy(),
-                        toggleWidget: sandbox.spy()
+                        hideSettings: sandbox.spy()
                     },
                     ui: {
                         text: {
@@ -57,7 +60,7 @@ describe('Header', () => {
 
             it('should call the toggleWidget action on header click', () => {
                 TestUtils.Simulate.click(headerNode);
-                props.actions.toggleWidget.should.have.been.calledOnce;
+                appService.toggleWidget.should.have.been.calledOnce;
             });
 
             it('should contain the show handle', () => {
@@ -115,7 +118,7 @@ describe('Header', () => {
 
         it('should call the toggleWidget action on header click', () => {
             TestUtils.Simulate.click(headerNode);
-            props.actions.toggleWidget.should.have.been.calledOnce;
+            appService.toggleWidget.should.have.been.calledOnce;
         });
 
         it('should not contain the show handle', () => {
@@ -179,7 +182,7 @@ describe('Header', () => {
 
         it('should call the toggleWidget action on header click', () => {
             TestUtils.Simulate.click(headerNode);
-            props.actions.toggleWidget.should.have.been.calledOnce;
+            appService.toggleWidget.should.have.been.calledOnce;
         });
 
         it('should not contain the show handle', () => {
@@ -244,7 +247,7 @@ describe('Header', () => {
 
         it('should not call the toggleWidget action on header click', () => {
             TestUtils.Simulate.click(headerNode);
-            props.actions.toggleWidget.should.not.have.been.called;
+            appService.toggleWidget.should.not.have.been.called;
         });
 
         it('should not contain the show handle', () => {
@@ -308,7 +311,7 @@ describe('Header', () => {
 
         it('should call the toggleWidget action on header click', () => {
             TestUtils.Simulate.click(headerNode);
-            props.actions.toggleWidget.should.have.been.calledOnce;
+            appService.toggleWidget.should.have.been.calledOnce;
         });
 
         it('should not contain the show handle', () => {
@@ -372,7 +375,7 @@ describe('Header', () => {
 
         it('should not call the toggleWidget action on header click', () => {
             TestUtils.Simulate.click(headerNode);
-            props.actions.toggleWidget.should.not.have.been.called;
+            appService.toggleWidget.should.not.have.been.called;
         });
 
         it('should not contain the show handle', () => {

--- a/test/specs/services/app-service.spec.js
+++ b/test/specs/services/app-service.spec.js
@@ -98,16 +98,20 @@ describe('App Service', () => {
                                 });
                             });
 
-                            it('should call dispatch with toggle action', () => {
+                            it(`should call dispatch with ${isOpened ? 'closed' : 'opened'} action`, () => {
                                 toggleWidget();
-                                mockedStore.dispatch.should.have.been.calledWith({
-                                    type: TOGGLE_WIDGET
-                                });
-
                                 if (isOpened) {
+                                    mockedStore.dispatch.should.have.been.calledWith({
+                                        type: CLOSE_WIDGET
+                                    });
+
                                     openSpy.should.not.have.been.called;
                                     closeSpy.should.have.been.calledOnce;
                                 } else {
+                                    mockedStore.dispatch.should.have.been.calledWith({
+                                        type: OPEN_WIDGET
+                                    });
+
                                     openSpy.should.have.been.calledOnce;
                                     closeSpy.should.not.have.been.called;
                                 }

--- a/test/specs/services/app-service.spec.js
+++ b/test/specs/services/app-service.spec.js
@@ -1,0 +1,121 @@
+import sinon from 'sinon';
+import { openWidget, closeWidget, toggleWidget } from 'services/app-service';
+import { mockAppStore } from 'test/utils/redux';
+import { OPEN_WIDGET, CLOSE_WIDGET, TOGGLE_WIDGET } from 'actions/app-state-actions';
+import { observable } from 'utils/events';
+
+describe('App Service', () => {
+    let mockedStore;
+    let sandbox;
+    let openSpy;
+    let closeSpy;
+
+    before(() => {
+        sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(() => {
+        openSpy = sandbox.spy();
+        closeSpy = sandbox.spy();
+
+        observable.on('widget:opened', openSpy);
+        observable.on('widget:closed', closeSpy);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        observable.off();
+    });
+
+    // embedded or not
+    [true, false].forEach((isEmbedded) => {
+        describe(isEmbedded ? 'is embedded' : 'is not embedded', () => {
+            beforeEach(() => {
+                mockedStore = mockAppStore(sandbox, {
+                    appState: {
+                        embedded: isEmbedded
+                    }
+                });
+            });
+
+            describe('open widget', () => {
+                if (isEmbedded) {
+                    it('should do nothing', () => {
+                        openWidget();
+                        mockedStore.dispatch.should.not.have.been.called;
+                        openSpy.should.not.have.been.called;
+                        closeSpy.should.not.have.been.called;
+                    });
+                } else {
+                    it('should call dispatch with open action', () => {
+                        openWidget();
+                        mockedStore.dispatch.should.have.been.calledWith({
+                            type: OPEN_WIDGET
+                        });
+                        openSpy.should.have.been.calledOnce;
+                        closeSpy.should.not.have.been.called;
+                    });
+                }
+            });
+
+            describe('close widget', () => {
+                if (isEmbedded) {
+                    it('should do nothing', () => {
+                        closeWidget();
+                        mockedStore.dispatch.should.not.have.been.called;
+                        openSpy.should.not.have.been.called;
+                        closeSpy.should.not.have.been.called;
+                    });
+                } else {
+                    it('should call dispatch with close action', () => {
+                        closeWidget();
+                        mockedStore.dispatch.should.have.been.calledWith({
+                            type: CLOSE_WIDGET
+                        });
+                        openSpy.should.not.have.been.called;
+                        closeSpy.should.have.been.calledOnce;
+                    });
+                }
+            });
+
+            describe('toggle widget', () => {
+                if (isEmbedded) {
+                    it('should do nothing', () => {
+                        toggleWidget();
+                        mockedStore.dispatch.should.not.have.been.called;
+                        openSpy.should.not.have.been.called;
+                        closeSpy.should.not.have.been.called;
+                    });
+                } else {
+                    [true, false].forEach((isOpened) => {
+                        describe(isOpened ? 'is opened' : 'is closed', () => {
+                            beforeEach(() => {
+                                mockedStore = mockAppStore(sandbox, {
+                                    appState: {
+                                        embedded: isEmbedded,
+                                        widgetOpened: isOpened
+                                    }
+                                });
+                            });
+
+                            it('should call dispatch with toggle action', () => {
+                                toggleWidget();
+                                mockedStore.dispatch.should.have.been.calledWith({
+                                    type: TOGGLE_WIDGET
+                                });
+
+                                if (isOpened) {
+                                    openSpy.should.not.have.been.called;
+                                    closeSpy.should.have.been.calledOnce;
+                                } else {
+                                    openSpy.should.have.been.calledOnce;
+                                    closeSpy.should.not.have.been.called;
+                                }
+                            });
+                        });
+                    });
+                }
+            });
+        });
+    });
+});

--- a/test/specs/utils/events.spec.js
+++ b/test/specs/utils/events.spec.js
@@ -13,30 +13,36 @@ describe('Events utils', () => {
             let firstHandler = sandbox.spy();
             let secondHandler = sandbox.spy();
             let thirdHandler = sandbox.spy();
+            let fourthHandler = sandbox.spy();
 
             let observable = new Observable();
 
             observable.on('1', firstHandler);
             observable.on('1', secondHandler);
             observable.on('2', thirdHandler);
+            observable.on('2', fourthHandler);
             observable.trigger('1');
 
             firstHandler.should.have.been.calledOnce;
             secondHandler.should.have.been.calledOnce;
             thirdHandler.should.not.have.been.called;
+            fourthHandler.should.not.have.been.called;
 
             firstHandler.reset();
             secondHandler.reset();
             thirdHandler.reset();
+            fourthHandler.reset();
 
             observable.trigger('2');
             firstHandler.should.not.have.been.called;
             secondHandler.should.not.have.been.called;
             thirdHandler.should.have.been.calledOnce;
+            fourthHandler.should.have.been.calledOnce;
 
             firstHandler.reset();
             secondHandler.reset();
             thirdHandler.reset();
+            fourthHandler.reset();
 
             observable.off('1', firstHandler);
             observable.trigger('1');
@@ -44,7 +50,33 @@ describe('Events utils', () => {
             firstHandler.should.not.have.been.called;
             secondHandler.should.have.been.calledOnce;
             thirdHandler.should.not.have.been.called;
+            fourthHandler.should.not.have.been.called;
 
+            firstHandler.reset();
+            secondHandler.reset();
+            thirdHandler.reset();
+            fourthHandler.reset();
+
+            observable.off('2');
+            observable.trigger('2');
+
+            firstHandler.should.not.have.been.called;
+            secondHandler.should.not.have.been.calledOnce;
+            thirdHandler.should.not.have.been.calledOnce;
+            fourthHandler.should.not.have.been.calledOnce;
+
+            firstHandler.reset();
+            secondHandler.reset();
+            thirdHandler.reset();
+            fourthHandler.reset();
+
+            observable.off();
+            observable.trigger('1');
+
+            firstHandler.should.not.have.been.called;
+            secondHandler.should.not.have.been.calledOnce;
+            thirdHandler.should.not.have.been.calledOnce;
+            fourthHandler.should.not.have.been.calledOnce;
         });
     });
 });


### PR DESCRIPTION
This adds hooks for opening and closing. I also added a `isOpened` method on the Smooch object to know the state. Also, to accomplish this, I added support to call `off` with no arguments to clear all listeners and the widget properly clean up itself when `destroy` is called.

This fixes #180 .

@mspensieri @dannytranlx @alavers @jugarrit 