### PR TITLE
Do not overwrite user properties on getConversation

### DIFF
--- a/src/js/actions/user-actions.js
+++ b/src/js/actions/user-actions.js
@@ -1,10 +1,18 @@
 export const SET_USER = 'SET_USER';
+export const UPDATE_USER = 'UPDATE_USER';
 export const RESET_USER = 'RESET_USER';
 
 export function setUser(props) {
     return {
         type: SET_USER,
         user: props
+    };
+}
+
+export function updateUser(properties) {
+    return {
+        type: UPDATE_USER,
+        properties
     };
 }
 

--- a/src/js/reducers/user-reducer.js
+++ b/src/js/reducers/user-reducer.js
@@ -1,4 +1,4 @@
-import { SET_USER, RESET_USER } from 'actions/user-actions';
+import { SET_USER, RESET_USER, UPDATE_USER } from 'actions/user-actions';
 import { RESET } from 'actions/common-actions';
 
 const INITIAL_STATE = {};
@@ -9,6 +9,8 @@ export function UserReducer(state = INITIAL_STATE, action) {
             return Object.assign({}, INITIAL_STATE);
         case SET_USER:
             return Object.assign({}, action.user);
+        case UPDATE_USER:
+            return Object.assign({}, state, action.properties);
         case RESET_USER:
             return INITIAL_STATE;
         default:

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -6,7 +6,7 @@ import pick from 'lodash.pick';
 import { store } from 'stores/app-store';
 
 import { setAuth, resetAuth } from 'actions/auth-actions';
-import { setUser, resetUser } from 'actions/user-actions';
+import * as userActions from 'actions/user-actions';
 import { setPublicKeys, setStripeInfo } from 'actions/app-actions';
 import { updateText } from 'actions/ui-actions';
 import { resetConversation } from 'actions/conversation-actions';
@@ -126,7 +126,7 @@ export class Smooch {
 
         // in case it comes from a previous authenticated state
         store.dispatch(resetAuth());
-        store.dispatch(resetUser());
+        store.dispatch(userActions.resetUser());
         store.dispatch(resetConversation());
         disconnectFaye();
 
@@ -161,7 +161,7 @@ export class Smooch {
                 }
             });
         }).then((loginResponse) => {
-            store.dispatch(setUser(loginResponse.appUser));
+            store.dispatch(userActions.setUser(loginResponse.appUser));
 
             if (loginResponse.publicKeys) {
                 store.dispatch(setPublicKeys(loginResponse.publicKeys));
@@ -222,7 +222,7 @@ export class Smooch {
 
     getConversation() {
         return handleConversationUpdated().then(() => {
-            store.dispatch(setUser({
+            store.dispatch(userActions.updateUser({
                 conversationStarted: true
             }));
             return store.getState().conversation;

--- a/test/specs/reducers/user-reducer.spec.js
+++ b/test/specs/reducers/user-reducer.spec.js
@@ -1,5 +1,5 @@
 import { UserReducer } from 'reducers/user-reducer';
-import { SET_USER, RESET_USER } from 'actions/user-actions';
+import { SET_USER, RESET_USER, UPDATE_USER } from 'actions/user-actions';
 
 describe('User reducer', () => {
     it('should be empty initialy', () => {
@@ -13,6 +13,20 @@ describe('User reducer', () => {
                 some: 'prop'
             }
         }).some.should.eq('prop');
+    });
+
+    it('should update user properties on UPDATE_USER', () => {
+        const newState = UserReducer({
+            _id: '12345'
+        }, {
+            type: UPDATE_USER,
+            properties: {
+                conversationStarted: true
+            }
+        });
+
+        newState.conversationStarted.should.eq(true);
+        newState._id.should.eq('12345');
     });
 
     it('should clear the state on RESET_USER', () => {

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -259,16 +259,39 @@ describe('Smooch', () => {
                     }
                 });
             });
+
+            it('should update conversationStarted to true ', () => {
+                return smooch.getConversation().then(() => {
+                    mockedStore.dispatch.should.have.been.calledWith({
+                        type: 'UPDATE_USER',
+                        properties: {
+                            conversationStarted: true
+                        }
+                    });
+                });
+            });
         });
 
         describe('conversation does not exist', () => {
             beforeEach(() => {
                 conversationService.handleConversationUpdated.rejects();
             });
+
             it('should reject', (done) => {
                 return smooch.getConversation()
                     .catch(() => done())
                     .then(() => done(new Error('Promise should not have resolved')));
+            });
+
+            it('should not update conversationStarted to true ', () => {
+                return smooch.getConversation().catch(() => {
+                    mockedStore.dispatch.should.not.have.been.calledWith({
+                        type: 'UPDATE_USER',
+                        properties: {
+                            conversationStarted: true
+                        }
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
@spasiu @lemieux @alavers 

Fixes #199, a bug introduced in #189. 

When `getConversation` succeeded, we were overwriting user properties, which means it became empty apart from having a `conversationStarted` property of true.