### PR TITLE
Retry resizing input if widget has no width

### DIFF
--- a/release_notes/v2.1.13.md
+++ b/release_notes/v2.1.13.md
@@ -1,0 +1,2 @@
+# Bug fix
+- When using the embedded mode, the input would sometimes have a width of 0 because the widget itself had no width at initial render time. It will now try up to 10 times in 1 second to get its width before resizing the input.

--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -36,7 +36,7 @@ export class ChatInputComponent extends Component {
         checkAndResetUnreadCount();
     }
 
-    resizeInput(depth = 0) {
+    resizeInput(attempt = 0) {
         const node = findDOMNode(this);
         if (node.offsetWidth - this.refs.button.offsetWidth > 0) {
             this.setState({
@@ -44,9 +44,9 @@ export class ChatInputComponent extends Component {
             });
         } else {
             // let's try it 10 times (so, 1 sec)
-            if (depth < 10) {
+            if (attempt < 10) {
                 setTimeout(() => {
-                    this.resizeInput(depth + 1);
+                    this.resizeInput(attempt + 1);
                 }, 100);
             } else {
                 // otherwise, let's hope 80% won't break it and won't look too silly

--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -35,11 +35,26 @@ export class ChatInputComponent extends Component {
     onFocus() {
         checkAndResetUnreadCount();
     }
-    resizeInput() {
+
+    resizeInput(depth = 0) {
         const node = findDOMNode(this);
-        this.setState({
-            inputContainerWidth: node.offsetWidth - this.refs.button.offsetWidth
-        });
+        if (node.offsetWidth - this.refs.button.offsetWidth > 0) {
+            this.setState({
+                inputContainerWidth: node.offsetWidth - this.refs.button.offsetWidth
+            });
+        } else {
+            // let's try it 10 times (so, 1 sec)
+            if (depth < 10) {
+                setTimeout(() => {
+                    this.resizeInput(depth + 1);
+                }, 100);
+            } else {
+                // otherwise, let's hope 80% won't break it and won't look too silly
+                this.setState({
+                    inputContainerWidth: '80%'
+                });
+            }
+        }
     }
 
     onSendMessage(e) {


### PR DESCRIPTION
When using the embed mode, it can happen that the widget has no width on the initial render. This would retry getting the width 10 times in 1 sec and then default to 80% width. The input is resize whenever the page is resized after that.

@alavers @dannytranlx @Mario54 @jugarrit 