### PR TITLE
Fix rounding issue for input width

### DIFF
--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -38,9 +38,17 @@ export class ChatInputComponent extends Component {
 
     resizeInput(attempt = 0) {
         const node = findDOMNode(this);
-        if (node.offsetWidth - this.refs.button.offsetWidth > 0) {
+
+        const nodeRect = node.getBoundingClientRect();
+        const buttonRect = this.refs.button.getBoundingClientRect();
+
+        // use floor on widget and ceil on button to get worst rounding scenario
+        const nodeWidth = Math.floor(nodeRect.width);
+        const buttonWidth = Math.ceil(buttonRect.width);
+
+        if (nodeWidth - buttonWidth > 0) {
             this.setState({
-                inputContainerWidth: node.offsetWidth - this.refs.button.offsetWidth
+                inputContainerWidth: nodeWidth - buttonWidth
             });
         } else {
             // let's try it 10 times (so, 1 sec)

--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -42,7 +42,7 @@ export class ChatInputComponent extends Component {
         const nodeRect = node.getBoundingClientRect();
         const buttonRect = this.refs.button.getBoundingClientRect();
 
-        // use floor on widget and ceil on button to get worst rounding scenario
+        // floor widget width and ceil button width to ensure button fits in widget
         const nodeWidth = Math.floor(nodeRect.width);
         const buttonWidth = Math.ceil(buttonRect.width);
 


### PR DESCRIPTION
As seen with the widget embedded in Elev.io, the input was just 1px to wide and was pushing the send button out. I realize that `offsetWidth` is always returning a rounded integer. In Elev.io case, the actual width (using the client rect) is 49.390625, but offsetWidth returns 49. This is just enough to break the footer rendering.

By using `getBoundingClientRect`, we ensure the real computed width is used and then we ceil it to get the worst case scenario.

@alavers @dannytranlx @jugarrit @mspensieri 