### PR TITLE
Trigger message event on message coming from getConversation

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -19,7 +19,7 @@ import { getAccount } from 'services/stripe-service';
 import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, updateNowViewing, immediateUpdate as immediateUpdateUser } from 'services/user-service';
 import { getConversation, sendMessage, connectFaye, disconnectFaye, handleConversationUpdated } from 'services/conversation-service';
 
-import { observable } from 'utils/events';
+import { observable, observeStore } from 'utils/events';
 import { storage } from 'utils/storage';
 import { waitForPage, monitorUrlChanges, stopMonitoringUrlChanges } from 'utils/dom';
 import { isImageUploadSupported } from 'utils/media';
@@ -73,6 +73,20 @@ observable.on('message:received', (message) => {
     observable.trigger('message', message);
 });
 
+let lastTriggeredMessageTimestamp = 0;
+let unsubscribeFromStore;
+
+function onStoreChange(messages) {
+    console.log('changed!')
+    messages.filter((message) => message.received > lastTriggeredMessageTimestamp).forEach((message) => {
+        if (message.role !== 'appUser') {
+            observable.trigger('message:received', message);
+        }
+
+        lastTriggeredMessageTimestamp = message.received;
+    });
+}
+
 export class Smooch {
     get VERSION() {
         return VERSION;
@@ -124,6 +138,8 @@ export class Smooch {
             store.dispatch(AppStateActions.setServerURL(props.serviceUrl));
         }
 
+        unsubscribeFromStore = observeStore(store, state => state.conversation.messages, onStoreChange.bind(this));
+
         return this.login(props.userId, props.jwt, pick(props, EDITABLE_PROPERTIES));
     }
 
@@ -155,6 +171,7 @@ export class Smooch {
             appToken: this.appToken
         }));
 
+        lastTriggeredMessageTimestamp = 0;
         return login({
             userId: userId,
             device: {
@@ -260,6 +277,7 @@ export class Smooch {
         }
 
         stopMonitoringUrlChanges();
+        unsubscribeFromStore();
 
         delete this.appToken;
         delete this._container;

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -83,10 +83,10 @@ function onStoreChange({messages, unreadCount}) {
             const filteredMessages = messages.filter((message) => message.role !== 'appUser');
             filteredMessages.slice(-unreadCount).filter((message) => message.received > lastTriggeredMessageTimestamp).forEach((message) => {
                 observable.trigger('message:received', message);
+                lastTriggeredMessageTimestamp = message.received;
             });
         }
-        
-        lastTriggeredMessageTimestamp = messages[messages.length - 1].received;
+
     }
 }
 

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -86,7 +86,6 @@ function onStoreChange({messages, unreadCount}) {
                 lastTriggeredMessageTimestamp = message.received;
             });
         }
-
     }
 }
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -41,6 +41,22 @@ export class Observable {
 
 export const observable = new Observable();
 
+export function observeStore(store, select, onChange) {
+    let currentState;
+
+    function handleChange() {
+        const nextState = select(store.getState());
+        if (nextState !== currentState) {
+            currentState = nextState;
+            onChange(currentState);
+        }
+    }
+
+    const unsubscribe = store.subscribe(handleChange);
+    handleChange();
+    return unsubscribe;
+}
+
 export function preventDefault(e) {
     e.preventDefault();
 }

--- a/src/js/utils/faye.js
+++ b/src/js/utils/faye.js
@@ -1,7 +1,6 @@
 import { Client } from 'faye';
 import urljoin from 'urljoin';
 
-import { observable } from 'utils/events';
 import { store } from 'stores/app-store';
 import { addMessage, incrementUnreadCount } from 'actions/conversation-actions';
 import { getConversation } from 'services/conversation-service';
@@ -41,7 +40,6 @@ export function initFaye() {
         return faye.subscribe('/conversations/' + state.conversation._id, (message) => {
             store.dispatch(addMessage(message));
             store.dispatch(incrementUnreadCount());
-            observable.trigger('message:received', message);
         });
     }
 }


### PR DESCRIPTION
Events weren't triggered when a new message was coming from getConversation or straight from init. Now appMaker messages and whispers are handled by computing which messages are new based on the unread count.

App user message are still triggered when the user actually send  them and this change doesn't touch that behavior.

@dannytranlx @mspensieri @alavers @Mario54 