### PR TITLE
Add detection for minor and major releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
                 upload: [{
                     src: 'dist/smooch.js',
                     dest: 'smooch.min.js'
-                },{
+                }, {
                     src: 'dist/smooch.js.map',
                     dest: 'smooch.js.map'
                 }]
@@ -188,6 +188,25 @@ module.exports = function(grunt) {
         var fullVersion = grunt.option('version');
         var versionType = grunt.option('versionType');
         var globalVersion;
+
+        // unless the version or increment is explicitely set, let's try
+        // to figure out what is the next version
+        if (!fullVersion && !versionType) {
+            var currentVersion = require('./package.json').version;
+            var nextPatchVersion = semver.inc(currentVersion, 'patch');
+            var nextMinorVersion = semver.inc(currentVersion, 'minor');
+            var nextMajorVersion = semver.inc(currentVersion, 'major');
+
+            fullVersion = [nextPatchVersion, nextMinorVersion, nextMajorVersion].find(function(version) {
+                try {
+                    grunt.file.read('release_notes/v' + version + '.md');
+                    return true;
+                }
+                catch (err) {
+                    return false;
+                }
+            });
+        }
 
         files.forEach(function(file) {
             var version = null;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -189,15 +189,15 @@ module.exports = function(grunt) {
         var versionType = grunt.option('versionType');
         var globalVersion;
 
-        // unless the version or increment is explicitely set, let's try
+        // unless the version or increment is explicitly set, let's try
         // to figure out what is the next version
         if (!fullVersion && !versionType) {
-            var currentVersion = require('./package.json').version;
-            var nextPatchVersion = semver.inc(currentVersion, 'patch');
-            var nextMinorVersion = semver.inc(currentVersion, 'minor');
-            var nextMajorVersion = semver.inc(currentVersion, 'major');
+            const currentVersion = require('./package.json').version;
+            const nextPatchVersion = semver.inc(currentVersion, 'patch');
+            const nextMinorVersion = semver.inc(currentVersion, 'minor');
+            const nextMajorVersion = semver.inc(currentVersion, 'major');
 
-            fullVersion = [nextPatchVersion, nextMinorVersion, nextMajorVersion].find(function(version) {
+            fullVersion = [nextPatchVersion, nextMinorVersion, nextMajorVersion].find((version) => {
                 try {
                     grunt.file.read('release_notes/v' + version + '.md');
                     return true;


### PR DESCRIPTION
This will allow us to deploy major and minor version through circle ci by creating release notes for that new version. This will only work for a clean major/minor version (to X.0.0 or X.X.0).

@jugarrit @dannytranlx @alavers @mspensieri 