### PR TITLE
Set conversationStarted to true after sending a message successfully

### DIFF
--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -1,5 +1,6 @@
 import { store } from 'stores/app-store';
 import { addMessage, removeMessage, setConversation, resetUnreadCount as resetUnreadCountAction } from 'actions/conversation-actions';
+import { updateUser } from 'actions/user-actions';
 import { showSettingsNotification, showErrorNotification } from 'actions/app-state-actions';
 import { setFayeSubscription, unsetFayeSubscription } from 'actions/faye-actions';
 import { core } from 'services/core';
@@ -55,6 +56,12 @@ export function sendMessage(text) {
         const user = store.getState().user;
 
         return core().conversations.sendMessage(user._id, message).then((response) => {
+            if (!user.conversationStarted) {
+                store.dispatch(updateUser({
+                    conversationStarted: true
+                }));
+            }
+
             store.dispatch(setConversation(response.conversation));
             observable.trigger('message:sent', response.message);
             return response;

--- a/test/specs/services/conversation-service.spec.js
+++ b/test/specs/services/conversation-service.spec.js
@@ -266,7 +266,7 @@ describe('Conversation service', () => {
                 mockedStore = mockAppStore(sandbox, {
                     user: {
                         _id: '1',
-                        conversationStarted: true
+                        conversationStarted: false
                     },
                     appState: {
                         settingsEnabled: true
@@ -294,6 +294,17 @@ describe('Conversation service', () => {
                     });
 
                     utilsFaye.initFaye.should.have.been.calledOnce;
+                });
+            });
+
+            it('should set conversationStarted to true', () => {
+                return conversationService.sendMessage('message').then(() => {
+                    mockedStore.dispatch.should.have.been.calledWith({
+                        type: 'UPDATE_USER',
+                        properties: {
+                            conversationStarted: true
+                        }
+                    });
                 });
             });
         });


### PR DESCRIPTION
@lemieux @dannytranlx @mspensieri @alavers 

After a first user message, if there was a whisper or a out-of-office reply added to the conversation it would not show up in the Web SDK because it was dispatched to faye before the widget could connect. And, since `conversationStarted` was false, it did not fetch the conversation when the connection to faye was established, which means we lost messages between the message being sent and connecting to faye.