### PR TITLE
Log warning when destroy is called before init Fixes #238

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -282,17 +282,21 @@ export class Smooch {
     }
 
     destroy() {
+        if (!this.appToken) {
+            console.warn('Smooch.destroy was called before Smooch.init was called properly.');
+        }
+
         const {embedded} = store.getState().appState;
         disconnectFaye();
         store.dispatch(reset());
-        if (process.env.NODE_ENV !== 'test') {
+        if (process.env.NODE_ENV !== 'test' && this._container) {
             unmountComponentAtNode(this._container);
         }
 
         if (embedded) {
             // retain the embed mode
             store.dispatch(AppStateActions.setEmbedded(true));
-        } else {
+        } else if (this._container) {
             document.body.removeChild(this._container);
         }
 

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -47,7 +47,7 @@ describe('Smooch', () => {
 
     beforeEach(() => {
         smooch = new Smooch();
-        smooch._el = 'el';
+        smooch._container = '_container';
         sandbox.stub(document.body, 'appendChild');
         sandbox.stub(document.body, 'removeChild');
         sandbox.stub(document, 'addEventListener', (eventName, cb) => {
@@ -371,13 +371,23 @@ describe('Smooch', () => {
             disconnectFayeStub = sandbox.stub(conversationService, 'disconnectFaye');
         });
 
-        it('should reset store state and remove el', () => {
+        it('should reset store state and remove the container', () => {
             smooch.destroy();
             mockedStore.dispatch.should.have.been.calledWith({
                 type: 'RESET'
             });
 
             document.body.removeChild.should.have.been.calledOnce;
+        });
+
+        it('should not remove the container from body if it is undefined', () => {
+            delete smooch._container;
+            smooch.destroy();
+            mockedStore.dispatch.should.have.been.calledWith({
+                type: 'RESET'
+            });
+
+            document.body.removeChild.should.not.have.been.calledOnce;
         });
     });
 


### PR DESCRIPTION
@lemieux @dannytranlx @mspensieri 

I also added a check for `this._container` before calling `unmountComponentAtNode` and `document.body.removeChild` on it in order to prevent errors.