### PR TITLE
When closing widget on mobile, prevent scrolling to the top of page

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -69,7 +69,7 @@
     }
     @media (max-width: @screen-sm-min) {
         width: 100%;
-        height: 100%;
+        height: auto;
     }
 }
 #sk-container.sk-embedded {

--- a/src/stylesheets/mobile.less
+++ b/src/stylesheets/mobile.less
@@ -4,8 +4,6 @@ html.sk-widget-opened {
         @media (max-width: @screen-sm-min) {
             overflow: hidden;
             position: relative;
-            height: 100%;
-            width: 100%;
             -webkit-overflow-scrolling: auto;
             #sk-holder {
                 #sk-container {


### PR DESCRIPTION
@lemieux @jugarrit @jpjoyal 

The fix to make chat scrolling work on mobile also introduced a separate bug. Setting the html body width and height to 100% scrolls the page back up to the top, frustrating if you open the widget on a long page you've scrolled deeply into.