### PR TITLE
Automatically dismiss error notifications after 10 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-spinkit": "1.1.4",
     "react-stripe-checkout": "1.7.2",
     "redux": "3.3.1",
+    "redux-thunk": "2.1.0",
     "smooch-core": "1.2.0",
     "urljoin": "0.1.5",
     "uuid": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "phantomjs-prebuilt": "2.1.4",
     "react-addons-test-utils": "0.14.7",
     "react-hot-loader": "1.3.0",
+    "redux-mock-store": "1.0.2",
     "semver": "4.3.6",
     "sinon": "2.0.0-pre",
     "sinon-as-promised": "4.0.0",

--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -118,7 +118,7 @@ export function setServerURL(url) {
 export function showErrorNotification(message) {
     return (dispatch) => {
         setTimeout(() => {
-            dispatch(hideErrorNotification(message));
+            dispatch(hideErrorNotification());
         }, 10000);
 
         dispatch({
@@ -128,10 +128,9 @@ export function showErrorNotification(message) {
     };
 }
 
-export function hideErrorNotification(message) {
+export function hideErrorNotification() {
     return {
-        type: HIDE_ERROR_NOTIFICATION,
-        message
+        type: HIDE_ERROR_NOTIFICATION
     };
 }
 

--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -18,8 +18,6 @@ export const SET_EMBEDDED = 'SET_EMBEDDED';
 export const ENABLE_IMAGE_UPLOAD = 'ENABLE_IMAGE_UPLOAD';
 export const DISABLE_IMAGE_UPLOAD = 'DISABLE_IMAGE_UPLOAD';
 
-const NOTIFICATION_HIDE_DELAY = 5000;
-
 export function toggleWidget() {
     return {
         type: TOGGLE_WIDGET
@@ -99,14 +97,8 @@ export function unsetEmailReadonly() {
 }
 
 export function showSettingsNotification() {
-    return (dispatch) => {
-        dispatch({
-            type: SHOW_SETTINGS_NOTIFICATION
-        });
-
-        setTimeout(() => {
-            dispatch(hideSettingsNotification());
-        }, NOTIFICATION_HIDE_DELAY);
+    return {
+        type: SHOW_SETTINGS_NOTIFICATION
     };
 }
 
@@ -126,13 +118,13 @@ export function setServerURL(url) {
 export function showErrorNotification(message) {
     return (dispatch) => {
         setTimeout(() => {
-            dispatch({
-                type: HIDE_ERROR_NOTIFICATION,
-                message
-            });
-        }, NOTIFICATION_HIDE_DELAY);
+            dispatch(hideErrorNotification(message));
+        }, 10000);
 
-        dispatch(hideErrorNotification(message));
+        dispatch({
+            type: SHOW_ERROR_NOTIFICATION,
+            message
+        });
     };
 }
 

--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -18,6 +18,8 @@ export const SET_EMBEDDED = 'SET_EMBEDDED';
 export const ENABLE_IMAGE_UPLOAD = 'ENABLE_IMAGE_UPLOAD';
 export const DISABLE_IMAGE_UPLOAD = 'DISABLE_IMAGE_UPLOAD';
 
+const NOTIFICATION_HIDE_DELAY = 5000;
+
 export function toggleWidget() {
     return {
         type: TOGGLE_WIDGET
@@ -97,8 +99,14 @@ export function unsetEmailReadonly() {
 }
 
 export function showSettingsNotification() {
-    return {
-        type: SHOW_SETTINGS_NOTIFICATION
+    return (dispatch) => {
+        dispatch({
+            type: SHOW_SETTINGS_NOTIFICATION
+        });
+
+        setTimeout(() => {
+            dispatch(hideSettingsNotification());
+        }, NOTIFICATION_HIDE_DELAY);
     };
 }
 
@@ -116,9 +124,15 @@ export function setServerURL(url) {
 }
 
 export function showErrorNotification(message) {
-    return {
-        type: SHOW_ERROR_NOTIFICATION,
-        message
+    return (dispatch) => {
+        setTimeout(() => {
+            dispatch({
+                type: HIDE_ERROR_NOTIFICATION,
+                message
+            });
+        }, NOTIFICATION_HIDE_DELAY);
+
+        dispatch(hideErrorNotification(message));
     };
 }
 

--- a/src/js/stores/configure-dev.js
+++ b/src/js/stores/configure-dev.js
@@ -1,7 +1,9 @@
-import { createStore, compose } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import { RootReducer } from 'reducers/root-reducer';
 
 const finalCreateStore = compose(
+    applyMiddleware(thunkMiddleware),
     window.devToolsExtension ? window.devToolsExtension() : (f) => f
 )(createStore);
 

--- a/src/js/stores/configure-prod.js
+++ b/src/js/stores/configure-prod.js
@@ -1,6 +1,11 @@
-import { createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import { RootReducer } from 'reducers/root-reducer';
 
+const createStoreWithMiddleware = applyMiddleware(
+    thunkMiddleware,
+)(createStore);
+
 export function configureStore(initialState) {
-    return createStore(RootReducer, initialState);
+    return createStoreWithMiddleware(RootReducer, initialState);
 }

--- a/src/stylesheets/notification.less
+++ b/src/stylesheets/notification.less
@@ -24,7 +24,7 @@
                 top: 0;
                 right: 10px;
 
-                display: none;
+                display: block;
 
                 width: 22px;
                 height: 32px;
@@ -33,11 +33,6 @@
                 text-decoration: none;
 
                 color: #808080;
-            }
-        }
-        &:hover {
-            .sk-notification-close {
-                display: block;
             }
         }
 

--- a/test/specs/services/conversation-service.spec.js
+++ b/test/specs/services/conversation-service.spec.js
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+
 import { createMock } from 'test/mocks/core';
 import { mockAppStore } from 'test/utils/redux';
 import * as coreService from 'services/core';
@@ -7,7 +8,6 @@ import * as utilsMedia from 'utils/media';
 import * as userService from 'services/user-service';
 import * as conversationService from 'services/conversation-service';
 import { SHOW_SETTINGS_NOTIFICATION, SHOW_ERROR_NOTIFICATION } from 'actions/app-state-actions';
-
 
 describe('Conversation service', () => {
     var sandbox;
@@ -474,7 +474,7 @@ describe('Conversation service', () => {
 
                 it('should show an error notification', () => {
                     return conversationService.uploadImage({}).catch(() => {
-                        mockedStore.dispatch.should.have.been.calledWith({
+                        mockedStore.getActions().should.include({
                             type: SHOW_ERROR_NOTIFICATION,
                             message: 'invalidFileError'
                         });

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -19,7 +19,9 @@ export function createMockedStore(sinon, mockedState = {}) {
 
     sinon.spy(store, 'dispatch');
     store.restore = restoreAppStore;
-    store.subscribe = () => Function();
+    store.subscribe = sinon.spy(() => {
+        return function() {};
+    });
     return store;
 }
 

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -1,4 +1,5 @@
-import { createStore } from 'redux';
+import { applyMiddleware, compose, createStore } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 
 const AppStore = require('stores/app-store');
 const store = AppStore.store;
@@ -12,7 +13,11 @@ function restoreAppStore() {
 }
 
 export function createMockedStore(sinon, mockedState = {}) {
-    const store = createStore(() => mockedState);
+    const createStoreWithMiddleware = compose(
+        applyMiddleware(thunkMiddleware)
+    )(createStore);
+
+    const store = createStoreWithMiddleware(() => mockedState);
 
     sinon.spy(store, 'dispatch');
     store.restore = restoreAppStore;

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -1,5 +1,5 @@
-import { applyMiddleware, compose, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import configureStore from 'redux-mock-store';
 
 const AppStore = require('stores/app-store');
 const store = AppStore.store;
@@ -13,14 +13,13 @@ function restoreAppStore() {
 }
 
 export function createMockedStore(sinon, mockedState = {}) {
-    const createStoreWithMiddleware = compose(
-        applyMiddleware(thunkMiddleware)
-    )(createStore);
-
-    const store = createStoreWithMiddleware(() => mockedState);
+    const middlewares = [thunkMiddleware];
+    const mockStore = configureStore(middlewares);
+    const store = mockStore(mockedState);
 
     sinon.spy(store, 'dispatch');
     store.restore = restoreAppStore;
+    store.subscribe = () => Function();
     return store;
 }
 


### PR DESCRIPTION
@lemieux @chloepouprom @liyefei737 @alavers @dannytranlx 

Using `redux-thunk` the `showErrorNotification` action will also dispatch a `hideErrorNotification` action after 10 seconds.

The style of the "x" button was changed, so that it is always shown to the user (not only when hovering the notification).
