### PR TITLE
Fix image rendering when uploading multiple

### DIFF
--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -61,8 +61,8 @@ export class ConversationComponent extends Component {
     }
 
     render() {
-        const messages = this.props.conversation.messages.map((message, index) => {
-            return <MessageComponent key={ index }
+        const messages = this.props.conversation.messages.map((message) => {
+            return <MessageComponent key={ message._clientId || message._id }
                                      accentColor={ this.props.settings.accentColor }
                                      linkColor={ this.props.settings.linkColor }
                                      onLoad={ this.scrollToBottom }

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -9,8 +9,8 @@ const INITIAL_STATE = {
 const sortMessages = (messages) => messages.sort((messageA, messageB) => {
     // received is undefined when it's the temp message from the user
     if (!messageA.received && !messageB.received) {
-        // `_tempSent` is a local only prop
-        return messageA._tempSent - messageB._tempSent;
+        // `_clientSent` is a local only prop
+        return messageA._clientSent - messageB._clientSent;
     }
 
     if (!messageA.received) {
@@ -34,6 +34,13 @@ const replaceMessage = (messages, query, newMessage) => {
     const existingMessage = messages.find((message) => matchMessage(message, query));
     if (!existingMessage) {
         return messages;
+    }
+
+    if (existingMessage._clientId) {
+        newMessage = {
+            ...newMessage,
+            _clientId: existingMessage._clientId
+        };
     }
 
     const index = messages.indexOf(existingMessage);

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -47,8 +47,8 @@ export function sendMessage(text) {
         const message = {
             role: 'appUser',
             text,
-            _tempId: Math.random(),
-            _tempSent: new Date(),
+            _clientId: Math.random(),
+            _clientSent: new Date(),
             deviceId: getDeviceId()
         };
 
@@ -64,7 +64,7 @@ export function sendMessage(text) {
             }
 
             store.dispatch(replaceMessage({
-                _tempId: message._tempId
+                _clientId: message._clientId
             }, response.message));
 
             observable.trigger('message:sent', response.message);
@@ -87,8 +87,8 @@ export function uploadImage(file) {
                 mediaType: 'image/jpeg',
                 role: 'appUser',
                 status: 'sending',
-                _tempId: Math.random(),
-                _tempSent: new Date()
+                _clientId: Math.random(),
+                _clientSent: new Date()
             };
 
             store.dispatch(addMessage(message));
@@ -101,14 +101,14 @@ export function uploadImage(file) {
                 deviceId: getDeviceId()
             }).then((response) => {
                 store.dispatch(replaceMessage({
-                    _tempId: message._tempId
+                    _clientId: message._clientId
                 }, response.message));
                 observable.trigger('message:sent', response.message);
                 return response;
             }).catch(() => {
                 store.dispatch(showErrorNotification(store.getState().ui.text.messageError));
                 store.dispatch(removeMessage({
-                    _tempId: message._tempId
+                    _clientId: message._clientId
                 }));
 
             });

--- a/test/specs/reducers/conversation-reducer.spec.js
+++ b/test/specs/reducers/conversation-reducer.spec.js
@@ -25,7 +25,7 @@ const MESSAGE_FROM_APP_USER = {
     received: 234.678,
     authorId: '8a9445dadad4862c2322db52',
     name: 'Calm Chimpanzee',
-    _tempId: '123498001'
+    _clientId: '123498001'
 };
 const MESSAGE_FROM_APP_MAKER_1 = {
     text: 'hello',
@@ -65,16 +65,16 @@ const UPLOADING_IMAGE_1 = {
     mediaType: 'image/jpeg',
     role: 'appUser',
     status: 'sending',
-    _tempId: 0.8288994217337065,
-    _tempSent: '2016-05-19T18:33:10.788Z'
+    _clientId: 0.8288994217337065,
+    _clientSent: '2016-05-19T18:33:10.788Z'
 };
 const UPLOADING_IMAGE_2 = {
     mediaUrl: 'data:image/jpeg',
     mediaType: 'image/jpeg',
     role: 'appUser',
     status: 'sending',
-    _tempId: 0.901823905092145,
-    _tempSent: '2016-05-19T19:34:10.788Z'
+    _clientId: 0.901823905092145,
+    _clientSent: '2016-05-19T19:34:10.788Z'
 };
 const RECEIVED_IMAGE = {
     text: 'some_media_url',
@@ -229,12 +229,15 @@ describe('Conversation reducer', () => {
                 type: REPLACE_MESSAGE,
                 message: RECEIVED_IMAGE,
                 queryProps: {
-                    _tempId: UPLOADING_IMAGE_1._tempId
+                    _clientId: UPLOADING_IMAGE_1._clientId
                 }
             });
             afterState.messages.length.should.eq(2);
             afterState.messages[1].should.not.eql(UPLOADING_IMAGE_1);
-            afterState.messages[1].should.eql(RECEIVED_IMAGE);
+            afterState.messages[1].should.eql({
+                ...RECEIVED_IMAGE,
+                _clientId: UPLOADING_IMAGE_1._clientId
+            });
         });
 
         it('should not remove anything if message to be removed does not exist', () => {
@@ -246,7 +249,7 @@ describe('Conversation reducer', () => {
                 type: REPLACE_MESSAGE,
                 message: RECEIVED_IMAGE,
                 queryProps: {
-                    _tempId: 1234
+                    _clientId: 1234
                 }
             });
             afterState.messages.length.should.eq(2);
@@ -262,11 +265,14 @@ describe('Conversation reducer', () => {
                 type: REPLACE_MESSAGE,
                 message: RECEIVED_IMAGE,
                 queryProps: {
-                    _tempId: UPLOADING_IMAGE_1._tempId
+                    _clientId: UPLOADING_IMAGE_1._clientId
                 }
             });
             afterState.messages.length.should.eq(2);
-            afterState.messages[0].should.eql(RECEIVED_IMAGE);
+            afterState.messages[0].should.eql({
+                ...RECEIVED_IMAGE,
+                _clientId: UPLOADING_IMAGE_1._clientId
+            });
             afterState.messages[1].should.eql(UPLOADING_IMAGE_2);
         });
     });
@@ -280,7 +286,7 @@ describe('Conversation reducer', () => {
             const afterState = ConversationReducer(beforeState, {
                 type: REMOVE_MESSAGE,
                 queryProps: {
-                    _tempId: MESSAGE_FROM_APP_USER._tempId
+                    _clientId: MESSAGE_FROM_APP_USER._clientId
                 }
             });
             afterState.messages.length.should.eq(0);


### PR DESCRIPTION
A rendering bug was happening when uploading multiple images in row. Since we were using `index` as the key in the message list, React was rerendering the message in a weird way and the same image was reused multiple times until all uploads were finished.

I also renamed `_temp*` variable to `_client*` to make it clearer it's in the client.

@chloepouprom @mspensieri @dannytranlx @liyefei737 @Mario54 