### PR TITLE
Remove sound notifications on initial load

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -64,6 +64,7 @@ observable.on('message:received', (message) => {
 });
 
 let lastTriggeredMessageTimestamp = 0;
+let initialStoreChange = true;
 let unsubscribeFromStore;
 
 function handleNotificationSound() {
@@ -83,7 +84,12 @@ function onStoreChange({messages, unreadCount}) {
             filteredMessages.slice(-unreadCount).filter((message) => message.received > lastTriggeredMessageTimestamp).forEach((message) => {
                 observable.trigger('message:received', message);
                 lastTriggeredMessageTimestamp = message.received;
-                handleNotificationSound();
+
+                if (initialStoreChange) {
+                    initialStoreChange = false;
+                } else {
+                    handleNotificationSound();
+                }
             });
         }
     }
@@ -181,6 +187,8 @@ export class Smooch {
         }));
 
         lastTriggeredMessageTimestamp = 0;
+        initialStoreChange = true;
+
         return login({
             userId: userId,
             device: {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -81,6 +81,7 @@ function onWindowBlur() {
 }
 
 export function monitorBrowserState() {
+    store.dispatch(hasFocus(document.hasFocus()));
     window.addEventListener('focus', onWindowFocus);
     window.addEventListener('blur', onWindowBlur);
 }


### PR DESCRIPTION
Sound notifications won't play on initial load anymore. Only on subsequent message received. 

The initial `hasFocus` was also set as `false`, so if you never `blur` or `focus` the window, it will assume the window to be not focused thus playing the sound. This will be fixed too. Grabbing the current state with `document.hasFocus()`. Not sure that is supported on most browser however.

I could also change the initial `hasFocus` to `true`. _Most_ of the time, we can assume the user _is_ on the page when loading the page. The only exception is if he `Cmd+Click` or `opened in new tab` the page (in which case, we won't play the sound anyway, because it will be on initial load).

@lemieux 
@chloepouprom 
@mspensieri 
@jugarrit 