### PR TITLE
Fix width of message bubble

### DIFF
--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -53,7 +53,7 @@ export class MessageComponent extends Component {
             <img className={ avatarClass.join(' ') }
                  src={ this.props.avatarUrl } />
             );
-        const avatarPlaceHolder = isAppUser ? null : (<div className='sk-msg-avatar-placeholder'/>);
+        const avatarPlaceHolder = isAppUser ? null : (<div className='sk-msg-avatar-placeholder' />);
 
         const message = this.props.mediaUrl ?
             <ImageMessage {...this.props} /> :
@@ -68,42 +68,43 @@ export class MessageComponent extends Component {
         const style = {};
 
         if (!this.props.mediaUrl) {
-          if (isAppUser && this.props.accentColor) {
-            style.backgroundColor = style.borderLeftColor = `#${this.props.accentColor}`;
-          }
+            if (isAppUser && this.props.accentColor) {
+                style.backgroundColor = style.borderLeftColor = `#${this.props.accentColor}`;
+            }
         }
         if (this.props.firstInGroup && !this.props.lastInGroup) {
-          if (isAppUser) {
-            containerClass.push('sk-msg-appuser-first');
-          } else {
-            containerClass.push('sk-msg-appmaker-first');
-          }
+            if (isAppUser) {
+                containerClass.push('sk-msg-appuser-first');
+            } else {
+                containerClass.push('sk-msg-appmaker-first');
+            }
         }
         if (this.props.lastInGroup && !this.props.firstInGroup) {
-          if (isAppUser) {
-            containerClass.push('sk-msg-appuser-last');
-          } else {
-            containerClass.push('sk-msg-appmaker-last');
-          }
+            if (isAppUser) {
+                containerClass.push('sk-msg-appuser-last');
+            } else {
+                containerClass.push('sk-msg-appmaker-last');
+            }
         }
         if (!this.props.firstInGroup && !this.props.lastInGroup) {
-          if (isAppUser) {
-            containerClass.push('sk-msg-appuser-middle');
-          } else {
-            containerClass.push('sk-msg-appmaker-middle');
-          }
+            if (isAppUser) {
+                containerClass.push('sk-msg-appuser-middle');
+            } else {
+                containerClass.push('sk-msg-appmaker-middle');
+            }
         }
 
         const fromName = <div className='sk-from'>
-                           { isAppUser ? '' : this.props.name }
-                       </div>;
+                             { isAppUser ? '' : this.props.name }
+                         </div>;
 
         return <div className={ 'sk-row ' + (isAppUser ? 'sk-right-row' : 'sk-left-row') }>
-                   {!isAppUser && this.props.firstInGroup ? fromName : ''}
+                   { !isAppUser && this.props.firstInGroup ? fromName : '' }
                    { this.props.lastInGroup ? avatar : avatarPlaceHolder }
                    <div className='sk-msg-wrapper'>
                        <div className={ containerClass.join(' ') }
-                            style={ style }>
+                            style={ style }
+                            ref='messageContent'>
                            { message }
                            { actions }
                        </div>

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -4,16 +4,7 @@ import { TextMessage } from './text-message';
 import { ImageMessage } from './image-message';
 import { ActionComponent } from './action';
 import { findDOMNode } from 'react-dom';
-
-const getElementProperties = (element) => {
-    return {
-        width: element.offsetWidth || 0,
-        height: element.offsetHeight || 0,
-        paddingLeft: window.getComputedStyle(element, null).getPropertyValue('padding-left'),
-        paddingRight: window.getComputedStyle(element, null).getPropertyValue('padding-right'),
-        fontSize: window.getComputedStyle(element, null).getPropertyValue('font-size')
-    };
-};
+import { getElementProperties } from '../utils/dom';
 
 export class MessageComponent extends Component {
     static defaultProps = {

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -12,7 +12,7 @@ export class MessageComponent extends Component {
     };
 
     componentDidMount() {
-        if (this.props.actions.length == 0) {
+        if (this.props.actions.length === 0) {
             this._restyleBubble();
         }
     }

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -3,12 +3,41 @@ import React, { Component } from 'react';
 import { TextMessage } from './text-message';
 import { ImageMessage } from './image-message';
 import { ActionComponent } from './action';
+import { findDOMNode } from 'react-dom';
 
+const getElementProperties = (element) => {
+    return {
+        width: element.offsetWidth || 0,
+        height: element.offsetHeight || 0,
+        paddingLeft: window.getComputedStyle(element, null).getPropertyValue('padding-left'),
+        paddingRight: window.getComputedStyle(element, null).getPropertyValue('padding-right'),
+        fontSize: window.getComputedStyle(element, null).getPropertyValue('font-size')
+    };
+};
 
 export class MessageComponent extends Component {
     static defaultProps = {
         actions: []
     };
+
+    componentDidMount() {
+        if (this.props.actions.length == 0) {
+            this._restyleBubble();
+        }
+    }
+
+    _restyleBubble() {
+        const bubble = findDOMNode(this.refs.messageContent);
+        if (bubble) {
+            const messageElement = bubble.firstChild;
+            const messageProperties = getElementProperties(messageElement);
+            const bubbleProperties = getElementProperties(bubble);
+            const multiLineCheck = parseInt(bubbleProperties.fontSize) * 2;
+            if (messageProperties.height > multiLineCheck && messageProperties.width < bubbleProperties.width) {
+                bubble.style.width = (messageProperties.width + parseInt(bubbleProperties.paddingLeft) + parseInt(bubbleProperties.paddingRight)) + 'px';
+            }
+        }
+    }
 
     render() {
         const actions = this.props.actions.map((action) => {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -93,11 +93,12 @@ export function stopMonitoringBrowserState() {
 }
 
 export function getElementProperties(element) {
+    const style = window.getComputedStyle(element, null);
     return {
         width: element.offsetWidth || 0,
         height: element.offsetHeight || 0,
-        paddingLeft: window.getComputedStyle(element, null).getPropertyValue('padding-left'),
-        paddingRight: window.getComputedStyle(element, null).getPropertyValue('padding-right'),
-        fontSize: window.getComputedStyle(element, null).getPropertyValue('font-size')
+        paddingLeft: style.getPropertyValue('padding-left'),
+        paddingRight: style.getPropertyValue('padding-right'),
+        fontSize: style.getPropertyValue('font-size')
     };
 }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -91,3 +91,13 @@ export function stopMonitoringBrowserState() {
     window.removeEventListener('focus', onWindowFocus);
     window.removeEventListener('blur', onWindowBlur);
 }
+
+export function getElementProperties(element) {
+    return {
+        width: element.offsetWidth || 0,
+        height: element.offsetHeight || 0,
+        paddingLeft: window.getComputedStyle(element, null).getPropertyValue('padding-left'),
+        paddingRight: window.getComputedStyle(element, null).getPropertyValue('padding-right'),
+        fontSize: window.getComputedStyle(element, null).getPropertyValue('font-size')
+    };
+}


### PR DESCRIPTION
These changes modify the width of message bubbles (à la fb messenger). 

Before:

<img width="272" alt="screen shot 2016-06-01 at 2 39 54 pm" src="https://cloud.githubusercontent.com/assets/4314491/15721363/acd55b48-2806-11e6-9a7f-b6593f1d044f.png">

After:
<img width="252" alt="screen shot 2016-06-01 at 2 40 23 pm" src="https://cloud.githubusercontent.com/assets/4314491/15721371/b20b171a-2806-11e6-9fcc-92c3a2484653.png">

Only small drawback is that the message width is calculated using `offsetWidth`, which can differ by 1px depending on the browser. Below is an example. If you guys think this could cause problems, let me know and I'll re-visit this.

Chrome (`width: 197px`):
<img width="314" alt="screen shot 2016-06-01 at 2 43 54 pm" src="https://cloud.githubusercontent.com/assets/4314491/15721516/567dbeba-2807-11e6-92f9-cfe498d0f347.png">

Firefox (`width: 196px`): 
<img width="331" alt="screen shot 2016-06-01 at 2 43 45 pm" src="https://cloud.githubusercontent.com/assets/4314491/15721520/5d7cca62-2807-11e6-92f6-17f5e755ed7c.png">


@dannytranlx @jugarrit @lemieux 