### PR TITLE
Fix widget animation on large screens

### DIFF
--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -49,6 +49,11 @@
 
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
+
+    @media (min-height: @large-desktop-height) {
+        -webkit-animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+    }
 }
 @-webkit-keyframes sk-close-frames {
     0% {
@@ -62,6 +67,24 @@
 @keyframes sk-close-frames {
     0% {
         top: 25vh;
+    }
+    100% {
+        top: @widget-close-top;
+    }
+}
+
+@-webkit-keyframes sk-close-frames-lg {
+    0% {
+        top: @widget-close-top-lg;
+    }
+    100% {
+        top: @widget-close-top;
+    }
+}
+
+@keyframes sk-close-frames-lg {
+    0% {
+        top: @widget-close-top-lg;
     }
     100% {
         top: @widget-close-top;

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -48,10 +48,10 @@
             background: @background-color;
             width: @widget-width;
             height: @widget-height;
-            max-height: 640px;
-            min-height: 420px;
-            max-width: 410px;
-            min-width: 330px;
+            max-height: @widget-max-height;
+            min-height: @widget-min-height;
+            max-width: @widget-max-width;
+            min-width: @widget-min-width;
             position: relative;
             border-radius: 10px 10px 0 0;
         }
@@ -64,6 +64,7 @@
                 &,
                 #sk-wrapper {
                     height: 100%;
+                    max-height: 100%;
                 }
             }
             #sk-wrapper {
@@ -122,7 +123,6 @@
         width: 100%;
     }
 }
-
 
 
 @import "mobile.less";

--- a/src/stylesheets/mobile.less
+++ b/src/stylesheets/mobile.less
@@ -5,6 +5,7 @@ html.sk-widget-opened {
             overflow: hidden;
             position: relative;
             -webkit-overflow-scrolling: auto;
+            max-height: 100%;
             #sk-holder {
                 #sk-container {
                     #sk-header {

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -26,3 +26,10 @@
 
 @sk-blue: #00aeff;
 @font-size-base: 14px;
+
+@widget-max-height: 640px;
+@widget-min-height: 420px;
+@widget-max-width: 410px;
+@widget-min-width: 330px;
+@large-desktop-height: 835px;
+@widget-close-top-lg: calc(~"100% - @{widget-max-height}");


### PR DESCRIPTION
Before (widget goes up a bit before going down - the larger your screen is, the more noticeable this will be):
![before_animation](https://cloud.githubusercontent.com/assets/4314491/15826259/dec9cbd0-2bd4-11e6-8352-4549a85a0f6c.gif)


After:
![after_animation](https://cloud.githubusercontent.com/assets/4314491/15826265/e8191cae-2bd4-11e6-94b1-651d396d0b11.gif)


@jugarrit @dannytranlx @lemieux 