### PR TITLE
Use media query breakpoints

### DIFF
--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -8,6 +8,11 @@
 
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
+
+    @media (min-width: @screen-lg-min) {
+        -webkit-animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+    }
 }
 
 .sk-appear #sk-handle {
@@ -24,7 +29,7 @@
 
 @-webkit-keyframes sk-appear-frames {
     0% {
-        bottom: @widget-close-bottom;
+        bottom: @widget-close-bottom-md;
     }
     100% {
         bottom: 0;
@@ -32,7 +37,24 @@
 }
 @keyframes sk-appear-frames {
     0% {
-        bottom: @widget-close-bottom;
+        bottom: @widget-close-bottom-md;
+    }
+    100% {
+        bottom: 0;
+    }
+}
+
+@-webkit-keyframes sk-appear-frames-lg {
+    0% {
+        bottom: @widget-close-bottom-lg;
+    }
+    100% {
+        bottom: 0;
+    }
+}
+@keyframes sk-appear-frames-lg {
+    0% {
+        bottom: @widget-close-bottom-lg;
     }
     100% {
         bottom: 0;
@@ -40,7 +62,7 @@
 }
 
 .sk-close {
-    bottom: @widget-close-bottom;
+    bottom: @widget-close-bottom-md;
 
     -webkit-animation: sk-close-frames .4s cubic-bezier(.62, .28, .23, .99);
             animation: sk-close-frames .4s cubic-bezier(.62, .28, .23, .99);
@@ -50,44 +72,45 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 
-    @media (min-height: @large-desktop-height) {
+    @media (min-width: @screen-lg-min) {
+        bottom: @widget-close-bottom-lg;
         -webkit-animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
 }
 @-webkit-keyframes sk-close-frames {
     0% {
-        top: 25vh;
+        bottom: 0;
 
     }
     100% {
-        top: @widget-close-top;
+        bottom: @widget-close-bottom-md;
     }
 }
 @keyframes sk-close-frames {
     0% {
-        top: 25vh;
+        bottom: 0;
     }
     100% {
-        top: @widget-close-top;
+        bottom: @widget-close-bottom-md;
     }
 }
 
 @-webkit-keyframes sk-close-frames-lg {
     0% {
-        top: @widget-close-top-lg;
+        bottom: 0;
+
     }
     100% {
-        top: @widget-close-top;
+        bottom: @widget-close-bottom-lg
     }
 }
-
 @keyframes sk-close-frames-lg {
     0% {
-        top: @widget-close-top-lg;
+        bottom: 0;
     }
     100% {
-        top: @widget-close-top;
+        bottom: @widget-close-bottom-lg;
     }
 }
 
@@ -101,6 +124,6 @@
      -khtml-user-select: none;
 }
 
-.sk-init, .sk-close {
+.sk-init {
     top: @widget-close-top;
 }

--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -13,6 +13,11 @@
         -webkit-animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
+    @media (max-width: @screen-sm-min) {
+        top: 0;
+        -webkit-animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
+    }
 }
 
 .sk-appear #sk-handle {
@@ -61,6 +66,23 @@
     }
 }
 
+@-webkit-keyframes sk-appear-frames-sm {
+    0% {
+        bottom: @widget-close-bottom-sm;
+    }
+    100% {
+        bottom: 0;
+    }
+}
+@keyframes sk-appear-frames-sm {
+    0% {
+        top: @widget-close-top;
+    }
+    100% {
+        top: 0;
+    }
+}
+
 .sk-close {
     bottom: @widget-close-bottom-md;
 
@@ -76,6 +98,13 @@
         bottom: @widget-close-bottom-lg;
         -webkit-animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+    }
+
+    @media (max-width: @screen-sm-min) {
+        bottom: @widget-close-bottom-sm;
+        top: @widget-close-top;
+        -webkit-animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
     }
 }
 @-webkit-keyframes sk-close-frames {
@@ -102,7 +131,7 @@
 
     }
     100% {
-        bottom: @widget-close-bottom-lg
+        bottom: @widget-close-bottom-lg;
     }
 }
 @keyframes sk-close-frames-lg {
@@ -111,6 +140,24 @@
     }
     100% {
         bottom: @widget-close-bottom-lg;
+    }
+}
+
+@-webkit-keyframes sk-close-frames-sm {
+    0% {
+        top: 0;
+
+    }
+    100% {
+        top: @widget-close-top;
+    }
+}
+@keyframes sk-close-frames-sm {
+    0% {
+       top: 0;
+    }
+    100% {
+        top: @widget-close-top;
     }
 }
 

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -98,7 +98,6 @@
     #sk-settings-header {
         cursor: default;
         border-radius: 0;
-        height: 50px;
         .sk-close-handle,
         .sk-show-handle {
             display: none;

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -36,7 +36,6 @@
     @import "reset.less";
     #sk-container {
         position: fixed;
-        bottom: @widget-close-bottom;
         right: 10px;
         margin-bottom: -1px;
         box-shadow: 0 0 24px rgba(0,0,0,0.15);
@@ -46,14 +45,14 @@
         .container();
         #sk-wrapper {
             background: @background-color;
-            width: @widget-width;
-            height: @widget-height;
-            max-height: @widget-max-height;
-            min-height: @widget-min-height;
-            max-width: @widget-max-width;
-            min-width: @widget-min-width;
+            width: @widget-width-md;
+            height: @widget-height-md;
             position: relative;
             border-radius: 10px 10px 0 0;
+            @media (min-width: @screen-lg-min) {
+                width: @widget-width-lg;
+                height: @widget-height-lg;
+            }
         }
         @media (max-width: @screen-sm-min) {
             right: 0;

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -119,6 +119,7 @@
     }
     .sk-settings {
         width: 100%;
+        height: @widget-height-md;
     }
 }
 

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -53,6 +53,10 @@
                 width: @widget-width-lg;
                 height: @widget-height-lg;
             }
+            @media (max-width: @screen-sm-min) {
+                width: @widget-width-sm;
+                height: @widget-height-sm;
+            }
         }
         @media (max-width: @screen-sm-min) {
             right: 0;
@@ -76,10 +80,6 @@
             border: 1px solid white;
             padding: 0px;
         }
-    }
-    @media (max-width: @screen-sm-min) {
-        width: 100%;
-        height: auto;
     }
 }
 #sk-container.sk-embedded {

--- a/src/stylesheets/settings.less
+++ b/src/stylesheets/settings.less
@@ -2,18 +2,20 @@
     box-sizing: border-box;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     position: absolute;
-    height: 100%;
     z-index: 2;
     background-color: white;
     overflow: hidden;
     opacity: 1;
     font-size: 13px;
     width: @widget-width-md;
+    height: @widget-height-md;
     @media (min-width: @screen-lg-min) {
         width: @widget-width-lg;
+        height: @widget-height-lg;
     }
     @media (max-width: @screen-sm-min) {
         width: @widget-width-sm;
+        height: @widget-height-sm;
     }
 
     .settings-wrapper {

--- a/src/stylesheets/settings.less
+++ b/src/stylesheets/settings.less
@@ -15,12 +15,17 @@
     @media (max-width: @screen-sm-min) {
         width: @widget-width-sm;
     }
-    
-
 
     .settings-wrapper {
         padding: 20px;
         box-sizing: border-box;
+        width: @widget-width-md;
+        @media (min-width: @screen-lg-min) {
+            width: @widget-width-lg;
+        }
+        @media (max-width: @screen-sm-min) {
+            width: @widget-width-sm;
+        }
 
         .input-group {
             position: relative;

--- a/src/stylesheets/settings.less
+++ b/src/stylesheets/settings.less
@@ -12,7 +12,7 @@
 
 
     .settings-wrapper {
-        width: @widget-width;
+        width: @widget-width-md;
         padding: 20px;
         box-sizing: border-box;
 
@@ -54,11 +54,11 @@
 
     &.settings-enter-active {
         .transition(width 250ms);
-        width: @widget-width;
+        width: 100%;
     }
 
     &.settings-leave {
-        width: @widget-width;
+        width: 100%;
     }
 
     &.settings-leave-active {

--- a/src/stylesheets/settings.less
+++ b/src/stylesheets/settings.less
@@ -2,23 +2,25 @@
     box-sizing: border-box;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     position: absolute;
-    width: 100%;
     height: 100%;
     z-index: 2;
     background-color: white;
     overflow: hidden;
     opacity: 1;
     font-size: 13px;
+    width: @widget-width-md;
+    @media (min-width: @screen-lg-min) {
+        width: @widget-width-lg;
+    }
+    @media (max-width: @screen-sm-min) {
+        width: @widget-width-sm;
+    }
+    
 
 
     .settings-wrapper {
-        width: @widget-width-md;
         padding: 20px;
         box-sizing: border-box;
-
-        @media (max-width: @screen-sm-min) {
-            width: 100%;
-        }
 
         .input-group {
             position: relative;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -1,7 +1,12 @@
 @background-color: #fff;
 
-@widget-height: 75vh;
-@widget-width: 30vw;
+@widget-height-md: 420px;
+@widget-height-lg: 640px;
+@widget-height-sm: 100%;
+
+@widget-width-md: 330px;
+@widget-width-lg: 410px;
+@widget-width-sm: 100%;
 
 @main-region-height-mobile: ~"calc(100% - @{footer-height} - @{header-height} - 2* @{header-padding})";
 
@@ -10,6 +15,9 @@
 @footer-height: 45px;
 
 @header-extra-height: (@header-height + 2 * @header-padding);
+@widget-close-bottom-md: -@widget-height-md + @header-extra-height;
+@widget-close-bottom-lg: -@widget-height-lg + @header-extra-height;
+@widget-close-bottom-sm: calc(~" @{header-extra-height} - @{widget-height-sm}");
 @widget-close-bottom: calc(~"@{header-extra-height} - @{widget-height}");
 @widget-close-top: calc(~"100% - @{header-extra-height}");
 

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -18,7 +18,6 @@
 @widget-close-bottom-md: -@widget-height-md + @header-extra-height;
 @widget-close-bottom-lg: -@widget-height-lg + @header-extra-height;
 @widget-close-bottom-sm: calc(~" @{header-extra-height} - @{widget-height-sm}");
-@widget-close-bottom: calc(~"@{header-extra-height} - @{widget-height}");
 @widget-close-top: calc(~"100% - @{header-extra-height}");
 
 @conversation-intro-height: 60px;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -17,7 +17,7 @@
 @header-extra-height: (@header-height + 2 * @header-padding);
 @widget-close-bottom-md: -@widget-height-md + @header-extra-height;
 @widget-close-bottom-lg: -@widget-height-lg + @header-extra-height;
-@widget-close-bottom-sm: calc(~" @{header-extra-height} - @{widget-height-sm}");
+@widget-close-bottom-sm: calc(~"@{header-extra-height} - @{widget-height-sm}");
 @widget-close-top: calc(~"100% - @{header-extra-height}");
 
 @conversation-intro-height: 60px;


### PR DESCRIPTION
Replace viewport attributes (`vh` and `vw`) with media query breakpoints.

- On large screens, widget will be 640x410.
- On smaller screens, widget will be 420x330.
- On phones and tablets, widget will take up width and height of device.

@lemieux @jugarrit @dannytranlx @mspensieri 