### PR TITLE
Fix Messenger button alignment

### DIFF
--- a/src/js/components/channels/messenger-channel-content.jsx
+++ b/src/js/components/channels/messenger-channel-content.jsx
@@ -33,10 +33,13 @@ export class MessengerChannelContent extends Component {
                     { `https://m.me/${pageId}` }
                 </a>
             </p> :
-            <MessengerPlugin appId={ appId }
-                             pageId={ pageId }
-                             passthroughParams={ smoochId }
-                             asyncScriptOnLoad={ this.facebookScriptDidLoad }
-                             size='large' />;
+            <div className='sk-fb-button-wrapper'>
+                <MessengerPlugin appId={ appId }
+                                 pageId={ pageId }
+                                 passthroughParams={ smoochId }
+                                 asyncScriptOnLoad={ this.facebookScriptDidLoad }
+                                 size='large' />
+            </div>;
+
     }
 }

--- a/src/stylesheets/channels.less
+++ b/src/stylesheets/channels.less
@@ -63,6 +63,10 @@
 
     }
 
+    .sk-fb-button-wrapper {
+        text-align: left;
+    }
+
     .fb-send-to-messenger {
         margin-left: 54px;
 


### PR DESCRIPTION
Since it was centered and the iframe width seems to change when the user is logged out, the button was misaligned because of the combination of align: center and the margin. By realigning to the left, it works great in both cases.

@Mario54 @dannytranlx @jugarrit @mspensieri @alavers 