### PR TITLE
Fix Messenger plugin unsolicited re-rendering

### DIFF
--- a/src/js/components/channels/messenger-channel-content.jsx
+++ b/src/js/components/channels/messenger-channel-content.jsx
@@ -22,6 +22,9 @@ export class MessengerChannelContent extends Component {
         }
     };
 
+    shouldComponentUpdate(nextProps, nextState) {
+        return nextState.sdkBlocked;
+    }
 
     render() {
         const {appId, pageId, smoochId} = this.props;
@@ -40,6 +43,5 @@ export class MessengerChannelContent extends Component {
                                  asyncScriptOnLoad={ this.facebookScriptDidLoad }
                                  size='large' />
             </div>;
-
     }
 }


### PR DESCRIPTION
On user clicks, the component was re-rendering, so it was killing the `iframe`making the request fail and the component flash.

@jpjoyal 
@lemieux 
@Mario54 
@jugarrit 
@chloepouprom 

https://trello.com/c/Awoob9x2/4017-web-sdk-linking-to-messenger-on-ios-often-takes-a-few-tries