### PR TITLE
Bump up react-redux version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-document-title": "2.0.1",
     "react-imageloader": "2.1.0",
     "react-messenger-plugin": "1.0.0",
-    "react-redux": "4.4.1",
+    "react-redux": "4.4.5",
     "react-spinkit": "1.1.4",
     "react-stripe-checkout": "1.7.2",
     "redux": "3.3.1",

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -22,10 +22,6 @@ export class ConversationComponent extends Component {
         errorNotificationMessage: PropTypes.string
     };
 
-    state = {
-        logoIsAnchored: true
-    };
-
     scrollTimeouts = [];
 
     onTouchStart = () => {


### PR DESCRIPTION
Some performance optimization was introduced in the newest version. I figure the widget was sometimes re-rendering itself for no reason and `connect` was doing a bad job of figuring out when to rerender.

@Mario54 @alavers @dannytranlx @jugarrit 