### PR TITLE
Add error banner for offline messagess

### DIFF
--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -97,6 +97,12 @@ export function sendMessage(text) {
 
             observable.trigger('message:sent', response.message);
             return response;
+        }).catch(() => {
+            store.dispatch(showErrorNotification(store.getState().ui.text.messageError));
+            store.dispatch(removeMessage({
+                _clientId: message._clientId
+            }));
+
         });
     });
 }


### PR DESCRIPTION
Add a catch to capture offline error, show banner and delete the message.
@lemieux @mspensieri @chloepouprom @jugarrit 