### PR TITLE
Remove render patch for unwanted rerender

### DIFF
--- a/src/js/components/channels/messenger-channel-content.jsx
+++ b/src/js/components/channels/messenger-channel-content.jsx
@@ -22,10 +22,6 @@ export class MessengerChannelContent extends Component {
         }
     };
 
-    shouldComponentUpdate(nextProps, nextState) {
-        return nextState.sdkBlocked;
-    }
-
     render() {
         const {appId, pageId, smoochId} = this.props;
 


### PR DESCRIPTION
This is pretty much unneeded now since the react-redux upgrade fixed it.

I smoketested the widget with that modification and it went fine.

@dannytranlx @jugarrit @mspensieri @alavers @chloepouprom 