### PR TITLE
Fix chubby widget on small height window + refactor

### DIFF
--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -9,17 +9,12 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-max) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
         -webkit-animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
 
-    @media (min-height: @screen-sm-ht-max) and (max-height: @screen-md-ht-max) and (min-width: @screen-sm-min) {
-        -webkit-animation: sk-appear-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-                animation: sk-appear-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-    }
-
-    @media (max-height: @screen-sm-ht-max) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
         -webkit-animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
     }
@@ -122,19 +117,13 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-max) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
         bottom: @widget-close-bottom-lg;
         -webkit-animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
 
-    @media (min-height: @screen-sm-ht-max) and (max-height: @screen-md-ht-max) and (min-width: @screen-sm-min) {
-        bottom: @widget-close-bottom-md;
-        -webkit-animation: sk-close-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-                animation: sk-close-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-    }
-
-    @media (max-height: @screen-sm-ht-max) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
         bottom: @widget-close-bottom-sm;
         -webkit-animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
@@ -230,15 +219,15 @@
 .sk-init {
     bottom: @widget-close-bottom-md;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-max) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
         bottom: @widget-close-bottom-lg;
     }
 
-    @media (min-height: @screen-sm-ht-max) and (max-height: @screen-md-ht-max) and (min-width: @screen-sm-min) {
+    @media (min-width: @screen-sm-min) and (min-height: @screen-sm-ht) and (max-height: @screen-md-ht) {
         bottom: @widget-close-bottom-md;
     }
 
-    @media (max-height: @screen-sm-ht-max) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
         bottom: @widget-close-bottom-sm;
     }
 

--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -24,9 +24,10 @@
                 animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
     }
 
+    // Mobile
     @media (max-width: @screen-sm-min) {
-        -webkit-animation: sk-appear-frames-fs .4s cubic-bezier(.62, .28, .23, .99);
-                animation: sk-appear-frames-fs .4s cubic-bezier(.62, .28, .23, .99);
+        -webkit-animation: sk-appear-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-appear-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
     }
 }
 
@@ -93,17 +94,17 @@
     }
 }
 
-@-webkit-keyframes sk-appear-frames-fs {
+@-webkit-keyframes sk-appear-frames-xs {
     0% {
-        bottom: @widget-close-bottom-fs;
+        bottom: @widget-close-bottom-xs;
     }
     100% {
         bottom: 0;
     }
 }
-@keyframes sk-appear-frames-fs {
+@keyframes sk-appear-frames-xs {
     0% {
-        bottom: @widget-close-bottom-fs;
+        bottom: @widget-close-bottom-xs;
     }
     100% {
         bottom: 0;
@@ -139,10 +140,11 @@
                 animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
     }
 
+    // Mobile
     @media (max-width: @screen-sm-min) {
-        bottom: @widget-close-bottom-fs;
-        -webkit-animation: sk-close-frames-fs .4s cubic-bezier(.62, .28, .23, .99);
-                animation: sk-close-frames-fs .4s cubic-bezier(.62, .28, .23, .99);
+        bottom: @widget-close-bottom-xs;
+        -webkit-animation: sk-close-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
+                animation: sk-close-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
     }
 }
 @-webkit-keyframes sk-close-frames-md {
@@ -198,20 +200,20 @@
     }
 }
 
-@-webkit-keyframes sk-close-frames-fs {
+@-webkit-keyframes sk-close-frames-xs {
     0% {
         bottom: 0;
     }
     100% {
-        bottom: @widget-close-bottom-fs;
+        bottom: @widget-close-bottom-xs;
     }
 }
-@keyframes sk-close-frames-fs {
+@keyframes sk-close-frames-xs {
     0% {
         bottom: 0;
     }
     100% {
-        bottom: @widget-close-bottom-fs;
+        bottom: @widget-close-bottom-xs;
     }
 }
 
@@ -240,7 +242,8 @@
         bottom: @widget-close-bottom-sm;
     }
 
+    // Mobiles
     @media (max-width: @screen-sm-min) {
-        bottom: @widget-close-bottom-fs;
+        bottom: @widget-close-bottom-xs;
     }
 }

--- a/src/stylesheets/channels.less
+++ b/src/stylesheets/channels.less
@@ -70,7 +70,7 @@
     .fb-send-to-messenger {
         margin-left: 54px;
 
-        @media (max-width: @widget-min-width) {
+        @media (max-width: @widget-width-sm) {
             margin-left: 0;
         }
 

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -101,7 +101,7 @@
             }
             @media (max-width: @screen-sm-min) or {
                 width: @widget-width-sm;
-                height: calc(~"@{widget-height-fs} - @{header-extra-height}");
+                height: calc(~"@{widget-height-xs} - @{header-extra-height}");
             }
         }
     }

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -50,17 +50,17 @@
             height: @widget-height-md;
             position: relative;
             border-radius: 10px 10px 0 0;
-            @media (min-height: @screen-md-ht-max) and (min-width: @screen-lg-min) {
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
                 width: @widget-width-lg;
                 height: @widget-height-lg;
             }
-            @media (max-height: @screen-md-ht-max) and (min-height: @screen-sm-ht-max) {
-                width: @widget-width-md;
-                height: @widget-height-md;
-            }
-            @media (max-height: @screen-sm-ht-max) {
+            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
                 width: @widget-width-sm;
-                height: @widget-height-fs;
+                height: @widget-height-sm;
+            }
+            @media (max-width: @screen-sm-min) {
+                width: @widget-width-xs;
+                height: @widget-height-xs;
             }
         }
         @media (max-width: @screen-sm-min) {
@@ -93,15 +93,19 @@
             overflow-y: auto;
 
             width: @widget-width-md;
-            height: calc(~"@{widget-height-md} - @{header-extra-height}");
+            height: @widget-height-md;
 
-            @media (min-width: @screen-lg-min) {
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
                 width: @widget-width-lg;
-                height: calc(~"@{widget-height-lg} - @{header-extra-height}");
+                height: @widget-height-lg;
             }
-            @media (max-width: @screen-sm-min) or {
+            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
                 width: @widget-width-sm;
-                height: calc(~"@{widget-height-xs} - @{header-extra-height}");
+                height: @widget-height-sm;
+            }
+            @media (max-width: @screen-sm-min) {
+                width: @widget-width-xs;
+                height: @widget-height-xs;
             }
         }
     }

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -1,13 +1,15 @@
 @background-color: #fff;
 
-@widget-height-md: 480px;
 @widget-height-lg: 640px;
-@widget-height-sm: 233px;
+@widget-height-md: 480px;
+@widget-height-sm: 420px;
 @widget-height-fs: 100%;
+@widget-height-xs: 100%;
 
-@widget-width-md: 350px;
 @widget-width-lg: 410px;
-@widget-width-sm: 100%;
+@widget-width-md: 350px;
+@widget-width-sm: 330px;
+@widget-width-xs: 100%;
 
 @main-region-height-mobile: ~"calc(100% - @{footer-height} - @{header-height} - 2* @{header-vertical-padding})";
 
@@ -20,7 +22,7 @@
 @widget-close-bottom-md: -@widget-height-md + @header-extra-height;
 @widget-close-bottom-lg: -@widget-height-lg + @header-extra-height;
 @widget-close-bottom-sm: -@widget-height-sm + @header-extra-height;
-@widget-close-bottom-fs: calc(~"@{header-extra-height} - @{widget-height-fs}");
+@widget-close-bottom-xs: calc(~"@{header-extra-height} - @{widget-height-xs}");
 @widget-close-top: calc(~"100% - @{header-extra-height}");
 
 @remaining-height: @header-extra-height + @footer-height;
@@ -45,7 +47,6 @@
 
 @settings-header-color: #464646;
 @settings-channel-item-border-color: #EFEFEF;
-
 
 @font-size-base: 14px;
 

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -50,12 +50,10 @@
 
 @font-size-base: 14px;
 
-@widget-max-height: 640px;
-@widget-min-height: 420px;
-@widget-max-width: 410px;
-@widget-min-width: 330px;
+@screen-sm-ht-max: 488px;
+@screen-md-ht-max: 648px;
 @large-desktop-height: 835px;
-@widget-close-top-lg: calc(~"100% - @{widget-max-height}");
+@widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
 
 @notification-height: 56px;
 @long-notification-height: 75px;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -3,7 +3,6 @@
 @widget-height-lg: 640px;
 @widget-height-md: 480px;
 @widget-height-sm: 420px;
-@widget-height-fs: 100%;
 @widget-height-xs: 100%;
 
 @widget-width-lg: 410px;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -50,9 +50,10 @@
 
 @font-size-base: 14px;
 
-@screen-sm-ht-max: 488px;
-@screen-md-ht-max: 648px;
-@large-desktop-height: 835px;
+@screen-lg-ht: 835px;
+@screen-md-ht: 648px;
+@screen-sm-ht: 488px;
+
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
 
 @notification-height: 56px;


### PR DESCRIPTION
- Changed the dimensions of the `sm` widget (this fixes the chubby widget bug)
- Renamed variables to follow bootstrap conventions.
- Code cleanup to make future responsive design easier :) 

There are four different widget dimensions:
- `lg`: 640px X 410px, displayed on screen width greater than 922px and screen height greater than 648px
- `md`: 480 px X 350px, displayed on screen width smaller than 922px and screen height smaller than 648px
- `sm`: 420px X 330px, displayed on screen width greater than 768px and screen height smaller than 488px
- `xs`: fullscreen, displayed on mobile devices (or when screen width is smaller than 768px)

@lemieux @liyefei737 @mspensieri @Mario54 @dannytranlx 