### PR TITLE
Use min and max variables for height breakpoints

### DIFF
--- a/release_notes/v3.1.3.md
+++ b/release_notes/v3.1.3.md
@@ -1,0 +1,2 @@
+# Changes
+- The widget seems to not know if it should be opened or not when the browser was exactly 648px tall. We showed it the right thing to do and now it stays closed when it needs to.

--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -9,18 +9,18 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
         -webkit-animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
 
-    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-max) {
         -webkit-animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
     }
 
     // Mobile
-    @media (max-width: @screen-sm-min) {
+    @media (max-width: @screen-xs-max) {
         -webkit-animation: sk-appear-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-appear-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
     }
@@ -117,13 +117,13 @@
     -webkit-animation-fill-mode: forwards;
             animation-fill-mode: forwards;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
         bottom: @widget-close-bottom-lg;
         -webkit-animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
     }
 
-    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-min) {
         bottom: @widget-close-bottom-sm;
         -webkit-animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
                 animation: sk-close-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
@@ -219,15 +219,15 @@
 .sk-init {
     bottom: @widget-close-bottom-md;
 
-    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
+    @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
         bottom: @widget-close-bottom-lg;
     }
 
-    @media (min-width: @screen-sm-min) and (min-height: @screen-sm-ht) and (max-height: @screen-md-ht) {
+    @media (min-width: @screen-sm-min) and (min-height: @screen-sm-ht-min) and (max-height: @screen-sm-ht-max) {
         bottom: @widget-close-bottom-md;
     }
 
-    @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
+    @media (min-width: @screen-sm-min) and (max-height: @screen-xs-ht-max) {
         bottom: @widget-close-bottom-sm;
     }
 

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -50,11 +50,11 @@
             height: @widget-height-md;
             position: relative;
             border-radius: 10px 10px 0 0;
-            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
                 width: @widget-width-lg;
                 height: @widget-height-lg;
             }
-            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
+            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-min) {
                 width: @widget-width-sm;
                 height: @widget-height-sm;
             }
@@ -95,11 +95,11 @@
             width: @widget-width-md;
             height: @widget-height-md;
 
-            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht) {
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
                 width: @widget-width-lg;
                 height: @widget-height-lg;
             }
-            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht) {
+            @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-min) {
                 width: @widget-width-sm;
                 height: @widget-height-sm;
             }

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -49,9 +49,13 @@
 
 @font-size-base: 14px;
 
-@screen-lg-ht: 835px;
-@screen-md-ht: 648px;
-@screen-sm-ht: 488px;
+@screen-lg-ht-min: 835px;
+@screen-md-ht-min: 648px;
+@screen-sm-ht-min: 488px;
+
+@screen-md-ht-min-max: @screen-lg-ht-min - 1;
+@screen-sm-ht-min-max: @screen-md-ht-min - 1;
+@screen-xs-ht-max: @screen-sm-ht-min - 1;
 
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
 

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -53,8 +53,8 @@
 @screen-md-ht-min: 648px;
 @screen-sm-ht-min: 488px;
 
-@screen-md-ht-min-max: @screen-lg-ht-min - 1;
-@screen-sm-ht-min-max: @screen-md-ht-min - 1;
+@screen-md-ht-max: @screen-lg-ht-min - 1;
+@screen-sm-ht-max: @screen-md-ht-min - 1;
 @screen-xs-ht-max: @screen-sm-ht-min - 1;
 
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");


### PR DESCRIPTION
At exactly 648px, the widget was half opened when it was supposed to be closed. That was caused by the overlap of two height breakpoints. This fixes this problem by having explicit max sizes depending on the next breakpoint.

@chloepouprom @alavers @dannytranlx @jugarrit @mspensieri 