### PR TITLE
Use badge color and contrast detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ bower_components
 tmp
 dist/
 lib/
-!webpack/lib/
-!src/js/lib/
 grunt-aws.json
 grunt-maxcdn.json
 *.sublime-workspace

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "webpack --config webpack-production.config.js --progress --profile --colors",
     "build:assets": "webpack --config webpack-assets.config.js --progress --profile --colors",
     "build:npm": "rm -rf lib/ && npm run babelify && npm run build:assets && rm -f lib/constants/*.mp3 && rm -f lib/constants/*.png",
-    "start-dev": "node dev-server/server-development",
+    "start-dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development",
     "start": "node dev-server/server-production",
     "lint": "eslint . --ext=js --ext=jsx",
     "babelify": "babel -d lib/ src/js/"
@@ -39,6 +39,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "blueimp-load-image": "2.6.0",
+    "color": "0.11.3",
     "deep-equal": "1.0.1",
     "faye": "1.1.2",
     "ismobilejs": "0.3.9",
@@ -120,6 +121,7 @@
     "less-loader": "2.2.2",
     "matchdep": "0.3.0",
     "mocha": "2.2.5",
+    "nodemon": "1.9.2",
     "phantomjs-prebuilt": "2.1.4",
     "react": "15.1.0",
     "react-addons-test-utils": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "blueimp-load-image": "2.6.0",
-    "color": "0.11.3",
     "deep-equal": "1.0.1",
     "faye": "1.1.2",
     "ismobilejs": "0.3.9",

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -69,12 +69,12 @@ export class ConversationComponent extends Component {
 
     render() {
         const {connectNotificationTimestamp, introHeight, messages, errorNotificationMessage} = this.props;
-        const {settings} = this.context;
+        const {accentColor, linkColor} = this.context.settings;
 
         let messageItems = messages.map((message) => {
             return <MessageComponent key={ message._clientId || message._id }
-                                     accentColor={ settings.accentColor }
-                                     linkColor={ settings.linkColor }
+                                     accentColor={ accentColor }
+                                     linkColor={ linkColor }
                                      onLoad={ this.scrollToBottom }
                                      {...message} />;
         });

--- a/src/js/components/header.jsx
+++ b/src/js/components/header.jsx
@@ -31,6 +31,7 @@ export class HeaderComponent extends Component {
         const {appState: {emailCaptureEnabled, settingsVisible, widgetOpened, embedded, visibleChannelType}, unreadCount} = this.props;
         const {ui, settings} = this.context;
         const {settingsHeaderText, headerText} = ui.text;
+        const {brandColor} = settings;
 
         const settingsMode = !!(settingsVisible || visibleChannelType);
         const showSettingsButton = (hasChannels(settings) || emailCaptureEnabled) && !settingsMode;
@@ -82,16 +83,22 @@ export class HeaderComponent extends Component {
                                  </div>
                              </div>;
 
-        return (
-            <div id={ settingsMode ? 'sk-settings-header' : 'sk-header' }
+        let style;
+        if (brandColor) {
+            style = {
+                backgroundColor: `#${brandColor}`
+            };
+        }
+
+        return <div id={ settingsMode ? 'sk-settings-header' : 'sk-header' }
                  onClick={ !embedded && toggleWidget }
-                 className='sk-header-wrapper'>
+                 className='sk-header-wrapper'
+                 style={ style }>
                 { settingsButton }
                 { settingsMode ? settingsText : headerText }
                 { unreadBadge }
                 { closeHandle }
-            </div>
-            );
+            </div>;
     }
 }
 

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -55,10 +55,9 @@ export class IntroductionComponent extends Component {
     }
 
     render() {
-        const {app, integrations} = this.props;
-        const {ui: {text}, settings: {brandColor}} = this.context;
-        const channelDetailsList = getAppChannelDetails(integrations);
-        
+        const {app, ui: {text}, settings: {brandColor}} = this.context;
+        const channelDetailsList = getAppChannelDetails(app.integrations);
+
         const channelsAvailable = channelDetailsList.length > 0;
         const introText = channelsAvailable ? `${text.introductionText} ${text.introAppText}` : text.introductionText;
 

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -56,7 +56,7 @@ export class IntroductionComponent extends Component {
 
     render() {
         const {app, integrations} = this.props;
-        const {ui: {text}, settings: {brandingColor}} = this.context;
+        const {ui: {text}, settings: {brandColor}} = this.context;
         const channelDetailsList = getAppChannelDetails(integrations);
         
         const channelsAvailable = channelDetailsList.length > 0;
@@ -65,7 +65,7 @@ export class IntroductionComponent extends Component {
         return <div className='sk-intro-section'>
                    { app.iconUrl ? <img className='app-icon'
                                         src={ app.iconUrl } />
-                         : <DefaultAppIcon color={ brandingColor } /> }
+                         : <DefaultAppIcon color={ brandColor } /> }
                    <div className='app-name'>
                        { app.name }
                    </div>

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -55,15 +55,17 @@ export class IntroductionComponent extends Component {
     }
 
     render() {
-        const {ui: {text}, settings: {accentColor}, app} = this.context;
-        const channelDetailsList = getAppChannelDetails(app.integrations);
+        const {app, integrations} = this.props;
+        const {ui: {text}, settings: {brandingColor}} = this.context;
+        const channelDetailsList = getAppChannelDetails(integrations);
+        
         const channelsAvailable = channelDetailsList.length > 0;
         const introText = channelsAvailable ? `${text.introductionText} ${text.introAppText}` : text.introductionText;
 
         return <div className='sk-intro-section'>
                    { app.iconUrl ? <img className='app-icon'
                                         src={ app.iconUrl } />
-                         : <DefaultAppIcon color={ accentColor } /> }
+                         : <DefaultAppIcon color={ brandingColor } /> }
                    <div className='app-name'>
                        { app.name }
                    </div>

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -65,7 +65,7 @@ export class WidgetComponent extends Component {
 
     render() {
         const {appState, settings, smoochId} = this.props;
-        const {brandingColorDark, accentColorDark, linkColorDark} = settings;
+        const {brandColorDark, accentColorDark, linkColorDark} = settings;
 
         const settingsComponent = appState.settingsVisible ? <Settings /> : null;
 
@@ -100,7 +100,7 @@ export class WidgetComponent extends Component {
             <ErrorNotification message={ appState.errorNotificationMessage } /> : null;
 
         const wrapperClassNames = [
-            `sk-branding-color-${brandingColorDark ? 'dark' : 'light'}`,
+            `sk-branding-color-${brandColorDark ? 'dark' : 'light'}`,
             `sk-accent-color-${accentColorDark ? 'dark' : 'light'}`,
             `sk-link-color-${linkColorDark ? 'dark' : 'light'}`
         ];

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -65,7 +65,7 @@ export class WidgetComponent extends Component {
 
     render() {
         const {appState, settings, smoochId} = this.props;
-        const {brandColorDark, accentColorDark, linkColorDark} = settings;
+        const {isBrandColorDark, isAccentColorDark, isLinkColorDark} = settings;
 
         const settingsComponent = appState.settingsVisible ? <Settings /> : null;
 
@@ -100,9 +100,9 @@ export class WidgetComponent extends Component {
             <ErrorNotification message={ appState.errorNotificationMessage } /> : null;
 
         const wrapperClassNames = [
-            `sk-branding-color-${brandColorDark ? 'dark' : 'light'}`,
-            `sk-accent-color-${accentColorDark ? 'dark' : 'light'}`,
-            `sk-link-color-${linkColorDark ? 'dark' : 'light'}`
+            `sk-branding-color-${isBrandColorDark ? 'dark' : 'light'}`,
+            `sk-accent-color-${isAccentColorDark ? 'dark' : 'light'}`,
+            `sk-link-color-${isLinkColorDark ? 'dark' : 'light'}`
         ];
 
         return (

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -65,6 +65,7 @@ export class WidgetComponent extends Component {
 
     render() {
         const {appState, settings, smoochId} = this.props;
+        const {brandingColorDark, accentColorDark, linkColorDark} = settings;
 
         const settingsComponent = appState.settingsVisible ? <Settings /> : null;
 
@@ -95,19 +96,24 @@ export class WidgetComponent extends Component {
             classNames.push('sk-ios-device');
         }
 
-        const className = classNames.join(' ');
-
         const notification = appState.errorNotificationMessage ?
             <ErrorNotification message={ appState.errorNotificationMessage } /> : null;
 
+        const wrapperClassNames = [
+            `sk-branding-color-${brandingColorDark ? 'dark' : 'light'}`,
+            `sk-accent-color-${accentColorDark ? 'dark' : 'light'}`,
+            `sk-link-color-${linkColorDark ? 'dark' : 'light'}`
+        ];
+
         return (
             <div id='sk-container'
-                 className={ className }
+                 className={ classNames.join(' ') }
                  onTouchStart={ this.onTouchStart }
                  onClick={ this.onClick }
                  onWheel={ this.onWheel }>
                 <MessageIndicator />
-                <div id='sk-wrapper'>
+                <div id='sk-wrapper'
+                     className={ wrapperClassNames.join(' ') }>
                     <Header />
                     <ReactCSSTransitionGroup component='div'
                                              className='sk-notification-container'
@@ -135,12 +141,7 @@ export class WidgetComponent extends Component {
     }
 }
 
-export const Widget = connect(({appState: {
-    settingsVisible,
-    widgetOpened,
-    errorNotificationMessage,
-    embedded
-}, app, ui, user}) => {
+export const Widget = connect(({appState: {settingsVisible, widgetOpened, errorNotificationMessage, embedded}, app, ui, user}) => {
     // only extract what is needed from appState as this is something that might
     // mutate a lot
     return {

--- a/src/js/reducers/app-reducer.js
+++ b/src/js/reducers/app-reducer.js
@@ -1,5 +1,7 @@
 import { SET_STRIPE_INFO, RESET_APP, SET_APP } from '../actions/app-actions';
 import { RESET } from '../actions/common-actions';
+import { isDark } from '../utils/colors';
+import { capitalizeFirstLetter } from '../utils/strings';
 
 const INITIAL_STATE = {
     integrations: [],
@@ -15,6 +17,37 @@ function filterIntegrations(integrations, channelSettings) {
     return integrations.filter(({platform}) => channelSettings[platform] !== false);
 }
 
+function computeColorsMetadata(settings) {
+    const metadata = {};
+
+    [{
+        key: 'brandColor',
+        isDefaultDark: true
+    }, {
+        key: 'accentColor',
+        isDefaultDark: true
+    }, {
+        key: 'linkColor',
+        isDefaultDark: true
+    }].forEach(({key, isDefaultDark}) => {
+        const metadataKey = `is${capitalizeFirstLetter(key)}Dark`;
+
+        if (settings[key]) {
+            try {
+                metadata[metadataKey] = isDark(`#${settings[key]}`);
+            }
+            catch (e) {
+                console.warn(`Invalid value for ${key}`);
+                metadata[metadataKey] = isDefaultDark;
+            }
+        } else {
+            metadata[metadataKey] = isDefaultDark;
+        }
+    });
+    
+    return metadata;
+}
+
 export function AppReducer(state = INITIAL_STATE, action) {
     switch (action.type) {
         case RESET:
@@ -26,6 +59,13 @@ export function AppReducer(state = INITIAL_STATE, action) {
         case SET_APP:
             return {
                 ...action.app,
+                settings: {
+                    ...action.app.settings,
+                    web: {
+                        ...action.app.settings.web,
+                        ...computeColorsMetadata(action.app.settings.web)
+                    }
+                },
                 integrations: filterIntegrations(action.app.integrations, action.app.settings.web)
             };
 

--- a/src/js/reducers/app-reducer.js
+++ b/src/js/reducers/app-reducer.js
@@ -1,3 +1,5 @@
+import Color from 'color';
+
 import { SET_STRIPE_INFO, RESET_APP, SET_APP } from '../actions/app-actions';
 import { RESET } from '../actions/common-actions';
 
@@ -15,6 +17,35 @@ function filterIntegrations(integrations, channelSettings) {
     return integrations.filter(({platform}) => channelSettings[platform] !== false);
 }
 
+function computeColorsMetadata(settings) {
+    const metadata = {};
+
+    [{
+        key: 'brandingColor',
+        isDefaultDark: false
+    }, {
+        key: 'accentColor',
+        isDefaultDark: true
+    }, {
+        key: 'linkColor',
+        isDefaultDark: true
+    }].forEach(({key, isDefaultDark}) => {
+        if (settings[key]) {
+            try {
+                const color = Color(`#${settings[key]}`);
+                metadata[`${key}Dark`] = color.dark();
+            }
+            catch (e) {
+                console.warn(`Invalid ${key}`);
+                metadata[`${key}Dark`] = isDefaultDark;
+            }
+        } else {
+            metadata[`${key}Dark`] = isDefaultDark;
+        }
+    });
+    return metadata;
+}
+
 export function AppReducer(state = INITIAL_STATE, action) {
     switch (action.type) {
         case RESET:
@@ -26,6 +57,12 @@ export function AppReducer(state = INITIAL_STATE, action) {
         case SET_APP:
             return {
                 ...action.app,
+                settings: {
+                    web: {
+                        ...action.app.settings.web,
+                        ...computeColorsMetadata(action.app.settings.web)
+                    }
+                },
                 integrations: filterIntegrations(action.app.integrations, action.app.settings.web)
             };
 

--- a/src/js/reducers/app-reducer.js
+++ b/src/js/reducers/app-reducer.js
@@ -1,5 +1,3 @@
-import Color from 'color';
-
 import { SET_STRIPE_INFO, RESET_APP, SET_APP } from '../actions/app-actions';
 import { RESET } from '../actions/common-actions';
 
@@ -17,35 +15,6 @@ function filterIntegrations(integrations, channelSettings) {
     return integrations.filter(({platform}) => channelSettings[platform] !== false);
 }
 
-function computeColorsMetadata(settings) {
-    const metadata = {};
-
-    [{
-        key: 'brandingColor',
-        isDefaultDark: false
-    }, {
-        key: 'accentColor',
-        isDefaultDark: true
-    }, {
-        key: 'linkColor',
-        isDefaultDark: true
-    }].forEach(({key, isDefaultDark}) => {
-        if (settings[key]) {
-            try {
-                const color = Color(`#${settings[key]}`);
-                metadata[`${key}Dark`] = color.dark();
-            }
-            catch (e) {
-                console.warn(`Invalid ${key}`);
-                metadata[`${key}Dark`] = isDefaultDark;
-            }
-        } else {
-            metadata[`${key}Dark`] = isDefaultDark;
-        }
-    });
-    return metadata;
-}
-
 export function AppReducer(state = INITIAL_STATE, action) {
     switch (action.type) {
         case RESET:
@@ -57,12 +26,6 @@ export function AppReducer(state = INITIAL_STATE, action) {
         case SET_APP:
             return {
                 ...action.app,
-                settings: {
-                    web: {
-                        ...action.app.settings.web,
-                        ...computeColorsMetadata(action.app.settings.web)
-                    }
-                },
                 integrations: filterIntegrations(action.app.integrations, action.app.settings.web)
             };
 

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -1,0 +1,39 @@
+// most utils were extract from https://github.com/Qix-/color
+
+export function getRGB(string) {
+    const abbr = /^#([a-fA-F0-9]{3})$/;
+    const hex = /^#([a-fA-F0-9]{6})$/;
+    const rgb = [0, 0, 0, 1];
+
+    let match = string.match(abbr);
+
+
+    if (match) {
+        match = match[1];
+
+        for (let i = 0; i < 3; i++) {
+            rgb[i] = parseInt(match[i] + match[i], 16);
+        }
+    } else {
+        match = string.match(hex);
+        if (match) {
+
+            match = match[1];
+
+            for (let i = 0; i < 3; i++) {
+                // https://jsperf.com/slice-vs-substr-vs-substring-methods-long-string/19
+                var i2 = i * 2;
+                rgb[i] = parseInt(match.slice(i2, i2 + 2), 16);
+            }
+        }
+    }
+
+    return rgb;
+}
+
+export function isDark(colorCode) {
+    const rgb = getRGB(colorCode);
+    // YIQ equation from http://24ways.org/2010/calculating-color-contrast
+    var yiq = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000;
+    return yiq < 128;
+}

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -1,0 +1,3 @@
+export function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -310,3 +310,27 @@
 
     }
 }
+
+.sk-accent-color-light {
+    #sk-conversation {
+        .sk-right-row {
+            .sk-msg, .sk-msg-image {
+                color: @sk-darker-grey;
+
+                a.link, a.link:visited {
+                    color: @sk-darker-grey;
+                }
+            }
+        }
+    }
+}
+
+.sk-link-color-light {
+    #sk-conversation {
+        .sk-left-row {
+            .btn {
+                color: @sk-darker-grey;
+            }
+        }
+    }
+}

--- a/src/stylesheets/header.less
+++ b/src/stylesheets/header.less
@@ -93,3 +93,10 @@
 #sk-settings-header {
     .header();
 }
+
+
+.sk-branding-color-dark {
+    .sk-header-wrapper {
+        color: #fff;
+    }
+}

--- a/src/stylesheets/header.less
+++ b/src/stylesheets/header.less
@@ -96,7 +96,9 @@
 
 
 .sk-branding-color-dark {
-    .sk-header-wrapper {
-        color: #fff;
+    #sk-header {
+        &, .fa {
+            color: #fff;
+        }
     }
 }


### PR DESCRIPTION
This pretty much allow the widget to use the new badgeColor field to customize the header. It also brings in constrast detection for better text color where any color customization is used. It means that if the original design was using blue background and white text, but you decided to use a yellow background, the text would switch to black.

Instead of going component per component to handle that customization, I decided to just add classes at the top of the widget and each component style who react based on that. It's much simpler and requires way less changes now and in the future.

Oh, yeah... I also tweak `npm run start-dev` to use nodemon and restart the server whenever an html file changes or a config file changes.

@chloepouprom @dannytranlx @alavers @mspensieri @Mario54 @jugarrit 