### PR TITLE
Reorder operations when destroying widget

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -294,13 +294,16 @@ export class Smooch {
             console.warn('Smooch.destroy was called before Smooch.init was called properly.');
         }
 
-        const {embedded} = store.getState().appState;
-        disconnectFaye();
-        store.dispatch(reset());
+        stopMonitoringBrowserState();
+        
         if (process.env.NODE_ENV !== 'test' && this._container) {
             unmountComponentAtNode(this._container);
         }
 
+        disconnectFaye();
+        store.dispatch(reset());
+
+        const {embedded} = store.getState().appState;
         if (embedded) {
             // retain the embed mode
             store.dispatch(AppStateActions.setEmbedded(true));
@@ -309,7 +312,6 @@ export class Smooch {
         }
 
         stopMonitoringUrlChanges();
-        stopMonitoringBrowserState();
         unsubscribeFromStore();
 
         delete this.appToken;

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -295,15 +295,15 @@ export class Smooch {
         }
 
         stopMonitoringBrowserState();
-        
+
         if (process.env.NODE_ENV !== 'test' && this._container) {
             unmountComponentAtNode(this._container);
         }
 
+        const {embedded} = store.getState().appState;
         disconnectFaye();
         store.dispatch(reset());
 
-        const {embedded} = store.getState().appState;
         if (embedded) {
             // retain the embed mode
             store.dispatch(AppStateActions.setEmbedded(true));


### PR DESCRIPTION
The widget was throwing errors on destroy because the Introduction component is recomputing  its height on update (`store.dispatch(reset());` was triggering an unnecessary update), but it's debounced so that computation was happening after the widget was unmounted. By rearranging the order of action, we ensure the the widget is properly unmounted and doesn't listen to the store before resetting anything.

@dannytranlx @jugarrit @mspensieri @Mario54 