### PR TITLE
Apply contrast detection to settings header

### DIFF
--- a/src/stylesheets/header.less
+++ b/src/stylesheets/header.less
@@ -96,7 +96,7 @@
 
 
 .sk-branding-color-dark {
-    #sk-header {
+    #sk-header, #sk-settings-header {
         &, .fa {
             color: #fff;
         }


### PR DESCRIPTION
Since the normal header and the settings header are not using the same id, the contrast logic wasn't applied to the settings and channels pages.

@chloepouprom @Mario54 @mspensieri @alavers @dannytranlx 