### PR TITLE
Auto deploy integration to staging website

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ deployment:
       - grunt deploy
 
   staging:
-    branch: f/staging-deployment
+    branch: integration
     commands:
       - npm run build:staging
       - aws s3 cp dist/smooch.js $SK_JS_STAGING_PATH > /dev/null

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,12 @@ deployment:
       - grunt publish
       - grunt deploy
 
+  staging:
+    branch: f/staging-deployment
+    commands:
+      - npm run build:staging
+      - aws s3 cp dist/smooch.js $SK_JS_STAGING_PATH
+
 
 experimental:
   notify:

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ deployment:
     branch: f/staging-deployment
     commands:
       - npm run build:staging
-      - aws s3 cp dist/smooch.js $SK_JS_STAGING_PATH
+      - aws s3 cp dist/smooch.js $SK_JS_STAGING_PATH > /dev/null
 
 
 experimental:

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -24,6 +24,8 @@ module.exports = function(options) {
         smooch: ['./src/js/utils/polyfills', './src/js/main']
     };
 
+    const fileLimit = options.bundleAll ? 100000 : 1;
+
     var loaders = {
         'jsx': options.hotComponents ? ['react-hot-loader', 'babel-loader'] : 'babel-loader',
         'js': {
@@ -31,11 +33,8 @@ module.exports = function(options) {
             include: [path.join(__dirname, 'src/js'), path.join(__dirname, 'test')]
         },
         'json': 'json-loader',
-        'txt': 'raw-loader',
-        'png|jpg|jpeg|gif|svg': 'url-loader?limit=1',
-        'woff|woff2': 'url-loader?limit=1',
-        'mp3': 'url-loader?limit=1',
-        'ttf|eot': 'file-loader'
+        'png|jpg|jpeg|gif|svg': `url-loader?limit=${fileLimit}`,
+        'mp3': `url-loader?limit=${fileLimit}`
     };
     var cssLoader = options.minimize ? 'css-loader?insertAt=top' : 'css-loader?insertAt=top&localIdentName=[path][name]---[local]---[hash:base64:5]';
     var stylesheetLoaders = {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev-server": "webpack-dev-server --config webpack-dev-server.config.js --colors --port 2992 --inline  --no-info",
     "hot-dev-server": "webpack-dev-server --config webpack-hot-dev-server.config.js --hot --colors --port 2992 --inline --no-info",
     "build": "webpack --config webpack-production.config.js --progress --profile --colors",
+    "build:staging": "webpack --config webpack-staging.config.js --progress --profile --colors",
     "build:assets": "webpack --config webpack-assets.config.js --progress --profile --colors",
     "build:npm": "rm -rf lib/ && npm run babelify && npm run build:assets && rm -f lib/constants/*.mp3 && rm -f lib/constants/*.png",
     "start-dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development",

--- a/webpack-staging.config.js
+++ b/webpack-staging.config.js
@@ -1,0 +1,5 @@
+module.exports = require('./make-webpack-config')({
+    minimize: true,
+    devtool: 'source-map',
+    bundleAll: true
+});


### PR DESCRIPTION
This will auto-deploy the integration branch whenever it gets a new commit to a staging website (which I'll give the link in slack). The only difference between the staging build and the production build is that the staging build is inlining all its resources to avoid having to mess around with cdn and stuff.

@alavers @dannytranlx @mspensieri @jmtremblay 