### PR TITLE
Update Twilio integration state with user information

### DIFF
--- a/src/js/components/channels/channel.jsx
+++ b/src/js/components/channels/channel.jsx
@@ -22,7 +22,8 @@ export class ChannelComponent extends Component {
         }
 
         const channelPages = getAppChannelDetails(appChannels).map(({channel, details}) => {
-            if (!details.Component || (isChannelLinked(clients, channel.type) && !details.renderPageIfLinked)) {
+            const linked = isChannelLinked(clients, channel.type);
+            if (!details.Component || (linked && !details.renderPageIfLinked)) {
                 return null;
             }
 
@@ -34,7 +35,8 @@ export class ChannelComponent extends Component {
                        <details.Component {...channel}
                                           channelState={ channelStates[channel.type] }
                                           getContent={ details.getContent }
-                                          smoochId={ smoochId } />
+                                          smoochId={ smoochId }
+                                          linked={ linked } />
                    </ChannelPage>;
         });
 

--- a/src/js/components/channels/twilio-channel-content.jsx
+++ b/src/js/components/channels/twilio-channel-content.jsx
@@ -127,7 +127,6 @@ export class TwilioChannelContentComponent extends Component {
 export const TwilioChannelContent = connect((state) => {
     return {
         ...state.integrations.twilio,
-        settings: state.app.settings.web,
-        user: state.user
+        settings: state.app.settings.web
     };
 })(TwilioChannelContentComponent);

--- a/src/js/components/channels/twilio-channel-content.jsx
+++ b/src/js/components/channels/twilio-channel-content.jsx
@@ -127,6 +127,7 @@ export class TwilioChannelContentComponent extends Component {
 export const TwilioChannelContent = connect((state) => {
     return {
         ...state.integrations.twilio,
-        settings: state.app.settings.web
+        settings: state.app.settings.web,
+        user: state.user
     };
 })(TwilioChannelContentComponent);

--- a/src/js/components/channels/twilio-channel-content.jsx
+++ b/src/js/components/channels/twilio-channel-content.jsx
@@ -10,7 +10,7 @@ export class TwilioChannelContentComponent extends Component {
 
     linkTwilioNumber = () => {
         updateTwilioAttributes({
-            number: this.props.number,
+            appUserNumber: this.props.appUserNumber,
             linkState: 'pending'
         });
     }
@@ -23,15 +23,15 @@ export class TwilioChannelContentComponent extends Component {
 
     handleInputChange = (telNumber) => {
         updateTwilioAttributes({
-            number: telNumber
+            appUserNumber: telNumber
         });
     }
 
     onChangeNumber = () => {
         updateTwilioAttributes({
             linkState: 'unlinked',
-            number: '',
-            numberValid: false
+            appUserNumber: '',
+            appUserNumberValid: false
         });
     }
 
@@ -49,13 +49,13 @@ export class TwilioChannelContentComponent extends Component {
 
     onNumberValid = () => {
         updateTwilioAttributes({
-            numberValid: true
+            appUserNumberValid: true
         });
     }
 
     onNumberInvalid = () => {
         updateTwilioAttributes({
-            numberValid: false
+            appUserNumberValid: false
         });
     }
 
@@ -64,7 +64,7 @@ export class TwilioChannelContentComponent extends Component {
     }
 
     render() {
-        const {number, numberValid, phoneNumber, linkState, settings: {linkColor}} = this.props;
+        const {appUserNumber, appUserNumberValid, phoneNumber, linkState, settings: {linkColor}} = this.props;
         let iconStyle = {};
         if (linkColor) {
             iconStyle = {
@@ -72,10 +72,10 @@ export class TwilioChannelContentComponent extends Component {
             };
         }
 
-        const linkButton = numberValid ? <button className='btn btn-sk-primary'
-                                                 onClick={ this.linkTwilioNumber }>
-                                             Continue
-                                         </button> : '';
+        const linkButton = appUserNumberValid ? <button className='btn btn-sk-primary'
+                                                        onClick={ this.linkTwilioNumber }>
+                                                    Continue
+                                                </button> : '';
         const unlinkedComponent = <div>
                                       <ReactTelephoneInput ref={ (c) => this._telInput = c }
                                                            defaultCountry='ca'
@@ -89,7 +89,7 @@ export class TwilioChannelContentComponent extends Component {
         const pendingComponent = <div className='twilio-linking pending-state'>
                                      <i className='fa fa-phone'
                                         style={ iconStyle }></i>
-                                     <span className='phone-number'>{ number } - Pending</span>
+                                     <span className='phone-number'>{ appUserNumber } - Pending</span>
                                      <a onClick={ this.onRetry }>Retry</a>
                                  </div>;
 
@@ -107,7 +107,7 @@ export class TwilioChannelContentComponent extends Component {
                                     <div className='twilio-linking linked-state'>
                                         <i className='fa fa-phone'
                                            style={ iconStyle }></i>
-                                        <span className='phone-number'>{ number }</span>
+                                        <span className='phone-number'>{ appUserNumber }</span>
                                         <a onClick={ this.onChangeNumber }>Change my number</a>
                                     </div>
                                     <a href={ sendTextUrl }>

--- a/src/js/constants/channels.js
+++ b/src/js/constants/channels.js
@@ -2,7 +2,7 @@ import isMobile from 'ismobilejs';
 
 import { integrations as integrationsAssets } from '../constants/assets';
 
-import { fetchWeChatQRCode } from '../services/integrations-service';
+import { fetchWeChatQRCode, fetchTwilioAttributes } from '../services/integrations-service';
 
 import { MessengerChannelContent } from '../components/channels/messenger-channel-content';
 import { EmailChannelContent } from '../components/channels/email-channel-content';
@@ -32,7 +32,8 @@ export const CHANNEL_DETAILS = {
         isLinkable: true,
         ...integrationsAssets.sms,
         renderPageIfLinked: true,
-        Component: TwilioChannelContent
+        Component: TwilioChannelContent,
+        onChannelPage: fetchTwilioAttributes
     },
     telegram: {
         name: 'Telegram',
@@ -62,7 +63,8 @@ export const CHANNEL_DETAILS = {
 Object.keys(CHANNEL_DETAILS).forEach((key) => {
     CHANNEL_DETAILS[key] = {
         renderPageIfLinked: false,
-        getURL: () => {},
+        getURL: () => {
+        },
         onChannelPage: () => Promise.resolve(),
         ...CHANNEL_DETAILS[key]
     };

--- a/src/js/reducers/integrations-reducer.js
+++ b/src/js/reducers/integrations-reducer.js
@@ -9,7 +9,7 @@ const INITIAL_STATE = {
     },
     twilio: {
         linkState: 'unlinked',
-        number: '',
+        appUserNumber: '',
         hasError: false
     }
 };

--- a/src/js/services/integrations-service.js
+++ b/src/js/services/integrations-service.js
@@ -35,13 +35,19 @@ export function resetTwilioAttributes() {
 }
 
 export function fetchTwilioAttributes() {
-    const {user: {clients}} = store.getState();
+    const {user: {clients, pendingClients}} = store.getState();
     const client = clients.find((client) => client.platform === 'twilio');
+    const pendingClient = pendingClients.find((client) => client.platform === 'twilio');
 
     if (client) {
         updateTwilioAttributes({
             linkState: 'linked',
             number: client.info.phoneNumber
+        });
+    } else if (pendingClient) {
+        updateTwilioAttributes({
+            linkState: 'pending',
+            number: pendingClient.info.phoneNumber
         });
     }
 }

--- a/src/js/services/integrations-service.js
+++ b/src/js/services/integrations-service.js
@@ -42,12 +42,12 @@ export function fetchTwilioAttributes() {
     if (client) {
         updateTwilioAttributes({
             linkState: 'linked',
-            number: client.info.phoneNumber
+            number: client.displayName
         });
     } else if (pendingClient) {
         updateTwilioAttributes({
             linkState: 'pending',
-            number: pendingClient.info.phoneNumber
+            number: pendingClient.displayName
         });
     }
 }

--- a/src/js/services/integrations-service.js
+++ b/src/js/services/integrations-service.js
@@ -33,3 +33,15 @@ export function updateTwilioAttributes(attr) {
 export function resetTwilioAttributes() {
     store.dispatch(resetTwilioIntegrationState());
 }
+
+export function fetchTwilioAttributes() {
+    const {user: {clients}} = store.getState();
+    const client = clients.find((client) => client.platform === 'twilio');
+
+    if (client) {
+        updateTwilioAttributes({
+            linkState: 'linked',
+            number: client.info.phoneNumber
+        });
+    }
+}

--- a/src/js/utils/user.js
+++ b/src/js/utils/user.js
@@ -7,7 +7,11 @@ export function isChannelLinked(clients, channelType) {
 
 export function getDisplayName(clients, channelType) {
     const client = clients.find((client) => client.platform === channelType);
-    return client && client.displayName;
+    if (channelType === 'twilio') {
+        return client && client.info && client.info.phoneNumber;
+    } else {
+        return client && client.displayName;
+    }
 }
 
 export function getLinkableChannels(appChannels, settings) {

--- a/src/js/utils/user.js
+++ b/src/js/utils/user.js
@@ -7,11 +7,7 @@ export function isChannelLinked(clients, channelType) {
 
 export function getDisplayName(clients, channelType) {
     const client = clients.find((client) => client.platform === channelType);
-    if (channelType === 'twilio') {
-        return client && client.info && client.info.phoneNumber;
-    } else {
-        return client && client.displayName;
-    }
+    return client && client.displayName;
 }
 
 export function getLinkableChannels(appChannels, settings) {

--- a/test/specs/components/channels/twilio-channel-component.spec.jsx
+++ b/test/specs/components/channels/twilio-channel-component.spec.jsx
@@ -1,0 +1,93 @@
+import sinon from 'sinon';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+
+import { mockComponent } from '../../../utils/react';
+import { ReactTelephoneInput } from '../../../../src/js/lib/react-telephone-input';
+
+import { TwilioChannelContentComponent } from '../../../../src/js/components/channels/twilio-channel-content';
+
+const sandbox = sinon.sandbox.create();
+
+describe('Twilio Channel Content Component', () => {
+    let component;
+
+    beforeEach(() => {
+        mockComponent(sandbox, ReactTelephoneInput, 'div', {
+            className: 'mockedTelephoneInput'
+        });
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('user has sms linking enabled', () => {
+        const linkedProps = {
+            number: '+151455555555',
+            linkState: 'linked',
+            phoneNumber: '123456789',
+            numberValid: true,
+            settings: {}
+        };
+        it('should render linked component', () => {
+            component = TestUtils.renderIntoDocument(<TwilioChannelContentComponent {...linkedProps}/>);
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'linked-state').length.should.eq(1);
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
+
+            const appUserPhoneNumber = TestUtils.findRenderedDOMComponentWithClass(component, 'phone-number');
+            appUserPhoneNumber.textContent.should.eq(linkedProps.number);
+
+            const appMakerPhoneNumber = TestUtils.scryRenderedDOMComponentsWithTag(component, 'a')[1];
+            const domNode = findDOMNode(appMakerPhoneNumber);
+            domNode.getAttribute('href').should.eql(`sms://${linkedProps.phoneNumber}`);
+        });
+    });
+
+    describe('user has sms linking disabled', () => {
+        const unlinkedProps = {
+            number: '',
+            linkState: 'unlinked',
+            phoneNumber: '123456789',
+            numberValid: false,
+            settings: {}
+        };
+
+        it('should render unlinked component', () => {
+            component = TestUtils.renderIntoDocument(<TwilioChannelContentComponent {...unlinkedProps}/>);
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(1);
+        });
+
+        [true, false].forEach((numberValid) => {
+            describe(`number is ${numberValid ? '' : 'not'} valid`, () => {
+                it(`should ${numberValid ? '' : 'not'} display Continue button`, () => {
+                    const props = {
+                        ...unlinkedProps,
+                        numberValid: numberValid
+                    };
+                    component = TestUtils.renderIntoDocument(<TwilioChannelContentComponent {...props}/>);
+                    TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-primary').length.should.eq(numberValid ? 1 : 0);
+                });
+            });
+        });
+    });
+
+    describe('user is in pending state', () => {
+        const pendingProps = {
+            number: '+15145555555',
+            linkState: 'pending',
+            phoneNumber: '123456789',
+            numberValid: true,
+            settings: {}
+        };
+
+        it('should render pending component', () => {
+            component = TestUtils.renderIntoDocument(<TwilioChannelContentComponent {...pendingProps}/>);
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
+
+            const appUserPhoneNumber = TestUtils.findRenderedDOMComponentWithClass(component, 'phone-number');
+            appUserPhoneNumber.textContent.should.eq(`${pendingProps.number} - Pending`);
+        });
+    });
+});

--- a/test/specs/components/channels/twilio-channel-component.spec.jsx
+++ b/test/specs/components/channels/twilio-channel-component.spec.jsx
@@ -25,10 +25,10 @@ describe('Twilio Channel Content Component', () => {
 
     describe('user has sms linking enabled', () => {
         const linkedProps = {
-            number: '+151455555555',
+            appUserNumber: '+151455555555',
             linkState: 'linked',
             phoneNumber: '123456789',
-            numberValid: true,
+            appUserNumberValid: true,
             settings: {}
         };
         it('should render linked component', () => {
@@ -37,7 +37,7 @@ describe('Twilio Channel Content Component', () => {
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
 
             const appUserPhoneNumber = TestUtils.findRenderedDOMComponentWithClass(component, 'phone-number');
-            appUserPhoneNumber.textContent.should.eq(linkedProps.number);
+            appUserPhoneNumber.textContent.should.eq(linkedProps.appUserNumber);
 
             const appMakerPhoneNumber = TestUtils.scryRenderedDOMComponentsWithTag(component, 'a')[1];
             const domNode = findDOMNode(appMakerPhoneNumber);
@@ -47,10 +47,10 @@ describe('Twilio Channel Content Component', () => {
 
     describe('user has sms linking disabled', () => {
         const unlinkedProps = {
-            number: '',
+            appUserNumber: '',
             linkState: 'unlinked',
             phoneNumber: '123456789',
-            numberValid: false,
+            appUserNumberValid: false,
             settings: {}
         };
 
@@ -59,15 +59,15 @@ describe('Twilio Channel Content Component', () => {
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(1);
         });
 
-        [true, false].forEach((numberValid) => {
-            describe(`number is ${numberValid ? '' : 'not'} valid`, () => {
-                it(`should ${numberValid ? '' : 'not'} display Continue button`, () => {
+        [true, false].forEach((appUserNumberValid) => {
+            describe(`appUserNumber is ${appUserNumberValid ? '' : 'not'} valid`, () => {
+                it(`should ${appUserNumberValid ? '' : 'not'} display Continue button`, () => {
                     const props = {
                         ...unlinkedProps,
-                        numberValid: numberValid
+                        appUserNumberValid: appUserNumberValid
                     };
                     component = TestUtils.renderIntoDocument(<TwilioChannelContentComponent {...props}/>);
-                    TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-primary').length.should.eq(numberValid ? 1 : 0);
+                    TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-primary').length.should.eq(appUserNumberValid ? 1 : 0);
                 });
             });
         });
@@ -75,10 +75,10 @@ describe('Twilio Channel Content Component', () => {
 
     describe('user is in pending state', () => {
         const pendingProps = {
-            number: '+15145555555',
+            appUserNumber: '+15145555555',
             linkState: 'pending',
             phoneNumber: '123456789',
-            numberValid: true,
+            appUserNumberValid: true,
             settings: {}
         };
 
@@ -87,7 +87,7 @@ describe('Twilio Channel Content Component', () => {
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
 
             const appUserPhoneNumber = TestUtils.findRenderedDOMComponentWithClass(component, 'phone-number');
-            appUserPhoneNumber.textContent.should.eq(`${pendingProps.number} - Pending`);
+            appUserPhoneNumber.textContent.should.eq(`${pendingProps.appUserNumber} - Pending`);
         });
     });
 });

--- a/test/specs/reducers/integrations-reducer.spec.js
+++ b/test/specs/reducers/integrations-reducer.spec.js
@@ -4,8 +4,8 @@ import { SET_TWILIO_INTEGRATION_STATE, RESET_TWILIO_INTEGRATION_STATE } from '..
 const INITIAL_STATE = IntegrationsReducer(undefined, {});
 const TWILIO_ATTRIBUTES = {
     linkState: 'linked',
-    number: '+15145555555',
-    numberValid: true
+    appUserNumber: '+15145555555',
+    appUserNumberValid: true
 }
 
 describe('Integrations Reducer', () => {
@@ -18,8 +18,8 @@ describe('Integrations Reducer', () => {
             });
             afterState.twilio.should.be.defined;
             afterState.twilio.linkState.should.eql(TWILIO_ATTRIBUTES.linkState);
-            afterState.twilio.number.should.eql(TWILIO_ATTRIBUTES.number);
-            afterState.twilio.numberValid.should.eql(TWILIO_ATTRIBUTES.numberValid);
+            afterState.twilio.appUserNumber.should.eql(TWILIO_ATTRIBUTES.appUserNumber);
+            afterState.twilio.appUserNumberValid.should.eql(TWILIO_ATTRIBUTES.appUserNumberValid);
         });
     });
 

--- a/test/specs/reducers/integrations-reducer.spec.js
+++ b/test/specs/reducers/integrations-reducer.spec.js
@@ -1,0 +1,41 @@
+import { IntegrationsReducer } from '../../../src/js/reducers/integrations-reducer';
+import { SET_TWILIO_INTEGRATION_STATE, RESET_TWILIO_INTEGRATION_STATE } from '../../../src/js/actions/integrations-actions';
+
+const INITIAL_STATE = IntegrationsReducer(undefined, {});
+const TWILIO_ATTRIBUTES = {
+    linkState: 'linked',
+    number: '+15145555555',
+    numberValid: true
+}
+
+describe('Integrations Reducer', () => {
+    describe('SET_TWILIO_INTEGRATION_STATE action', () => {
+        it('should update with new twilio attributes', () => {
+            const beforeState = INITIAL_STATE;
+            const afterState = IntegrationsReducer(beforeState, {
+                type: SET_TWILIO_INTEGRATION_STATE,
+                attrs: TWILIO_ATTRIBUTES
+            });
+            afterState.twilio.should.be.defined;
+            afterState.twilio.linkState.should.eql(TWILIO_ATTRIBUTES.linkState);
+            afterState.twilio.number.should.eql(TWILIO_ATTRIBUTES.number);
+            afterState.twilio.numberValid.should.eql(TWILIO_ATTRIBUTES.numberValid);
+        });
+    });
+
+    describe('RESET_TWILIO_INTEGRATION_STATE action', () => {
+        it('should reset the default twilio attributes', () => {
+            const beforeState = {
+                integrations: {
+                    twilio: {
+                        ...TWILIO_ATTRIBUTES
+                    }
+                }
+            };
+            const afterState = IntegrationsReducer(beforeState, {
+                type: RESET_TWILIO_INTEGRATION_STATE
+            });
+            afterState.should.eql(INITIAL_STATE);
+        });
+    });
+});

--- a/test/specs/utils/user.spec.js
+++ b/test/specs/utils/user.spec.js
@@ -30,6 +30,7 @@ describe('User Utils', () => {
                 id: '123456789',
                 platform: 'twilio',
                 linkedAt: '2016-07-25T18:53:05.064Z',
+                displayName: '+15145555555',
                 info: {
                     phoneNumber: '+15145555555',
                     country: 'CA',
@@ -43,7 +44,7 @@ describe('User Utils', () => {
             describe(`${platform} channel`, () => {
                 it(`should return ${platform === 'messenger' ? 'display name' : 'phone number'}`, () => {
                     const displayName = getDisplayName(CLIENTS, platform);
-                    displayName.should.eql(platform === 'messenger' ? CLIENTS[1].displayName : CLIENTS[2].info.phoneNumber);
+                    displayName.should.eql(platform === 'messenger' ? CLIENTS[1].displayName : CLIENTS[2].displayName);
                 });
             });
         });

--- a/test/specs/utils/user.spec.js
+++ b/test/specs/utils/user.spec.js
@@ -1,0 +1,51 @@
+import { getDisplayName } from '../../../src/js/utils/user';
+
+describe('User Utils', () => {
+    describe('getDisplayName', () => {
+        const CLIENTS = [
+            {
+                lastSeen: '2016-07-25T20:58:25.533Z',
+                info: {
+                    sdkVersion: '3.1.2',
+                    URL: '',
+                    userAgent: '',
+                    referrer: '',
+                    browserLanguage: '',
+                    currentUrl: '',
+                    currentTitle: ''
+                },
+                platform: 'web',
+                id: 'abcdefghijklmnop',
+                active: true
+            },
+            {
+                displayName: 'Beep Boop',
+                id: '987654321',
+                platform: 'messenger',
+                linkedAt: '2016-07-25T15:30:56.549Z',
+                active: true
+            },
+            {
+                lastSeen: '2016-07-25T18:53:05.069Z',
+                id: '123456789',
+                platform: 'twilio',
+                linkedAt: '2016-07-25T18:53:05.064Z',
+                info: {
+                    phoneNumber: '+15145555555',
+                    country: 'CA',
+                    city: 'MONTREAL',
+                    state: 'QC'
+                },
+                active: true
+            }];
+
+        ['messenger', 'twilio'].forEach((platform) => {
+            describe(`${platform} channel`, () => {
+                it(`should return ${platform === 'messenger' ? 'display name' : 'phone number'}`, () => {
+                    const displayName = getDisplayName(CLIENTS, platform);
+                    displayName.should.eql(platform === 'messenger' ? CLIENTS[1].displayName : CLIENTS[2].info.phoneNumber);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
The state is now updated with the correct Twilio-related information. That way, if the user already has SMS linking enabled, the right view will be displayed.

I also added a few frontend tests!

@jugarrit @liyefei737 @lemieux @Mario54 @mspensieri 