### PR TITLE
Fix unread badge overlap

### DIFF
--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -89,8 +89,8 @@ export class MessengerButtonComponent extends Component {
                     className={ `messenger-button-${shown ? 'shown' : 'hidden'}` }
                     style={ style }
                     onClick={ this.onClick }>
-                   { unreadBadge }
                    { content }
+                   { unreadBadge }
                </div>;
     }
 }

--- a/src/stylesheets/unread-badge.less
+++ b/src/stylesheets/unread-badge.less
@@ -12,6 +12,7 @@
 #sk-messenger-button {
     .unread-badge {
         position: absolute;
+        top: 0;
     }
 }
 


### PR DESCRIPTION
Just reordered the component to make sure the unread badge appears on top of the icon
![image](https://cloud.githubusercontent.com/assets/781844/17226218/509d95a0-54d6-11e6-8f21-e10aa1a9b043.png)

@alavers @mspensieri @Mario54 @jpjoyal @jugarrit @dannytranlx 