### PR TITLE
Prevent intro height calcuation when closing

### DIFF
--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -93,24 +93,22 @@ export class ChatInputComponent extends Component {
             inputContainerClasses.push('no-upload');
         }
 
-        return (
-            <div id='sk-footer'>
-                { imageUploadButton }
-                <form onSubmit={ this.onSendMessage }
-                      action='#'>
-                    <div className={ inputContainerClasses.join(' ') }>
-                        <input ref='input'
-                               placeholder={ ui.text.inputPlaceholder }
-                               className='input message-input'
-                               onChange={ this.onChange }
-                               onFocus={ this.onFocus }
-                               value={ this.state.text }
-                               title={ ui.text.sendButtonText }></input>
-                    </div>
-                </form>
-                { sendButton }
-            </div>
-            );
+        return <div id='sk-footer'>
+                   { imageUploadButton }
+                   <form onSubmit={ this.onSendMessage }
+                         action='#'>
+                       <div className={ inputContainerClasses.join(' ') }>
+                           <input ref='input'
+                                  placeholder={ ui.text.inputPlaceholder }
+                                  className='input message-input'
+                                  onChange={ this.onChange }
+                                  onFocus={ this.onFocus }
+                                  value={ this.state.text }
+                                  title={ ui.text.sendButtonText }></input>
+                       </div>
+                   </form>
+                   { sendButton }
+               </div>;
     }
 }
 

--- a/src/js/components/header.jsx
+++ b/src/js/components/header.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { toggleWidget, showSettings, hideSettings, hideChannelPage } from '../services/app-service';
 import { hasChannels } from '../utils/app';
 import { CHANNEL_DETAILS } from '../constants/channels';
+import { WIDGET_STATE } from '../constants/app';
 
 export class HeaderComponent extends Component {
 
@@ -28,13 +29,14 @@ export class HeaderComponent extends Component {
     }
 
     render() {
-        const {appState: {emailCaptureEnabled, settingsVisible, widgetOpened, embedded, visibleChannelType}, unreadCount} = this.props;
+        const {appState: {emailCaptureEnabled, settingsVisible, widgetState, embedded, visibleChannelType}, unreadCount} = this.props;
         const {ui, settings} = this.context;
         const {settingsHeaderText, headerText} = ui.text;
         const {brandColor} = settings;
 
         const settingsMode = !!(settingsVisible || visibleChannelType);
         const showSettingsButton = (hasChannels(settings) || emailCaptureEnabled) && !settingsMode;
+        const widgetOpened = widgetState === WIDGET_STATE.OPENED;
 
         const unreadBadge = !settingsMode && unreadCount > 0 ? (
             <div className='unread-badge'>
@@ -96,12 +98,12 @@ export class HeaderComponent extends Component {
     }
 }
 
-function mapStateToProps({appState: {emailCaptureEnabled, settingsVisible, widgetOpened, embedded, visibleChannelType}, conversation}) {
+function mapStateToProps({appState: {emailCaptureEnabled, settingsVisible, widgetState, embedded, visibleChannelType}, conversation}) {
     return {
         appState: {
             emailCaptureEnabled,
             settingsVisible,
-            widgetOpened,
+            widgetState,
             embedded,
             visibleChannelType
         },

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -10,6 +10,7 @@ import { setIntroHeight } from '../actions/app-state-actions';
 
 import { createMarkup } from '../utils/html';
 import { getAppChannelDetails } from '../utils/app';
+import { WIDGET_STATE } from '../constants/app';
 
 export class IntroductionComponent extends Component {
     static propTypes = {
@@ -25,7 +26,6 @@ export class IntroductionComponent extends Component {
 
     constructor(...args) {
         super(...args);
-
         this._debounceHeightCalculation = debounce(this.calculateIntroHeight.bind(this), 150);
     }
 
@@ -43,14 +43,18 @@ export class IntroductionComponent extends Component {
     }
 
     calculateIntroHeight() {
-        const node = findDOMNode(this);
-        const {appState: {introHeight}, dispatch} = this.props;
+        const {appState: {introHeight, widgetState}, dispatch} = this.props;
 
-        const nodeRect = node.getBoundingClientRect();
-        const nodeHeight = Math.floor(nodeRect.height);
+        // don't recalculate height if widget is closed or closing
+        if (widgetState === WIDGET_STATE.OPENED) {
+            const node = findDOMNode(this);
 
-        if (introHeight !== nodeHeight) {
-            dispatch(setIntroHeight(nodeHeight));
+            const nodeRect = node.getBoundingClientRect();
+            const nodeHeight = Math.floor(nodeRect.height);
+
+            if (introHeight !== nodeHeight) {
+                dispatch(setIntroHeight(nodeHeight));
+            }
         }
     }
 
@@ -77,10 +81,11 @@ export class IntroductionComponent extends Component {
     }
 }
 
-export const Introduction = connect(({appState: {introHeight}}) => {
+export const Introduction = connect(({appState: {introHeight, widgetState}}) => {
     return {
         appState: {
-            introHeight
+            introHeight,
+            widgetState
         }
     };
 })(IntroductionComponent);

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -17,6 +17,7 @@ import { MessageIndicator } from './message-indicator';
 import { resetUnreadCount } from '../services/conversation-service';
 import { hasChannels } from '../utils/app';
 import { DISPLAY_STYLE } from '../constants/styles';
+import { WIDGET_STATE } from '../constants/app';
 
 export class WidgetComponent extends Component {
     static propTypes = {
@@ -84,14 +85,12 @@ export class WidgetComponent extends Component {
         if (appState.embedded) {
             classNames.push('sk-embedded');
         } else {
-            // `widgetOpened` can have 3 values: `true`, `false`, and `undefined`.
-            // `undefined` is basically the default state where the widget was never
-            // opened or closed and not visibility class is applied to the widget
-            if (appState.widgetOpened === true) {
+            if (appState.widgetState === WIDGET_STATE.OPENED) {
                 classNames.push('sk-appear');
-            } else if (appState.widgetOpened === false) {
+            } else if (appState.widgetState === WIDGET_STATE.CLOSED) {
                 classNames.push('sk-close');
             } else {
+                // state is WIDGET_STATE.INIT
                 classNames.push('sk-init');
             }
         }
@@ -112,7 +111,7 @@ export class WidgetComponent extends Component {
         let messengerButton;
 
         if (displayStyle === DISPLAY_STYLE.BUTTON && !appState.embedded) {
-            messengerButton = <MessengerButton shown={ !appState.widgetOpened } />;
+            messengerButton = <MessengerButton shown={ appState.widgetState !== WIDGET_STATE.OPENED } />;
         }
 
         return <div>
@@ -152,13 +151,13 @@ export class WidgetComponent extends Component {
     }
 }
 
-export const Widget = connect(({appState: {settingsVisible, widgetOpened, errorNotificationMessage, embedded}, app, ui, user}) => {
+export const Widget = connect(({appState: {settingsVisible, widgetState, errorNotificationMessage, embedded}, app, ui, user}) => {
     // only extract what is needed from appState as this is something that might
     // mutate a lot
     return {
         appState: {
             settingsVisible,
-            widgetOpened,
+            widgetState,
             errorNotificationMessage,
             embedded
         },

--- a/src/js/constants/app.js
+++ b/src/js/constants/app.js
@@ -1,0 +1,5 @@
+export const WIDGET_STATE = {
+    OPENED: Symbol('opened'),
+    CLOSED: Symbol('closed'),
+    INIT: Symbol('init')
+};

--- a/src/js/reducers/app-state-reducer.js
+++ b/src/js/reducers/app-state-reducer.js
@@ -1,11 +1,12 @@
 import * as AppStateActions from '../actions/app-state-actions';
 import { RESET } from '../actions/common-actions';
 import { RESET_CONVERSATION } from '../actions/conversation-actions';
+import { WIDGET_STATE } from '../constants/app';
 
 const INITIAL_STATE = {
     settingsVisible: false,
     visibleChannelType: null,
-    widgetOpened: null,
+    widgetState: WIDGET_STATE.INIT,
     settingsEnabled: true,
     soundNotificationEnabled: true,
     imageUploadEnabled: true,
@@ -79,23 +80,24 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
             };
 
         case AppStateActions.TOGGLE_WIDGET:
+
             return {
                 ...state,
-                widgetOpened: !state.widgetOpened,
-                settingsVisible: state.settingsVisible && !state.widgetOpened
+                widgetState: state.widgetState === WIDGET_STATE.OPENED ? WIDGET_STATE.CLOSED : WIDGET_STATE.OPENED,
+                settingsVisible: state.settingsVisible && state.widgetState !== WIDGET_STATE.OPENED
             };
 
         case AppStateActions.OPEN_WIDGET:
             return {
                 ...state,
-                widgetOpened: true
+                widgetState: WIDGET_STATE.OPENED
             };
 
         case AppStateActions.CLOSE_WIDGET:
             return {
                 ...state,
                 visibleChannelType: null,
-                widgetOpened: false,
+                widgetState: WIDGET_STATE.CLOSED,
                 settingsVisible: false
             };
 
@@ -157,7 +159,7 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
             return {
                 ...state,
                 embedded: action.value,
-                widgetOpened: action.value ? true : state.widgetOpened
+                widgetState: action.value ? WIDGET_STATE.OPENED : state.widgetState
             };
 
         case AppStateActions.SET_INTRO_HEIGHT:

--- a/src/js/services/app-service.js
+++ b/src/js/services/app-service.js
@@ -6,6 +6,7 @@ import { observable } from '../utils/events';
 import { hasLinkableChannels, isChannelLinked } from '../utils/user';
 import { getIntegration } from '../utils/app';
 import { CHANNEL_DETAILS } from '../constants/channels';
+import { WIDGET_STATE } from '../constants/app';
 
 export function openWidget() {
     const {embedded} = store.getState().appState;
@@ -29,9 +30,9 @@ export function closeWidget() {
 
 
 export function toggleWidget() {
-    const {embedded, widgetOpened} = store.getState().appState;
+    const {embedded, widgetState} = store.getState().appState;
     if (!embedded) {
-        if (widgetOpened) {
+        if (widgetState === WIDGET_STATE.OPENED) {
             closeWidget();
         } else {
             openWidget();

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -27,8 +27,8 @@ import { getDeviceId } from './utils/device';
 import { getIntegration, hasChannels } from './utils/app';
 
 import { stylesheet } from './constants/assets';
-
 import { VERSION } from './constants/version';
+import { WIDGET_STATE } from './constants/app';
 
 import { Root } from './root';
 
@@ -330,7 +330,7 @@ export class Smooch {
     }
 
     isOpened() {
-        return !!store.getState().appState.widgetOpened;
+        return !!store.getState().appState.widgetState === WIDGET_STATE.OPENED;
     }
 
     render(container) {

--- a/src/stylesheets/mixins.less
+++ b/src/stylesheets/mixins.less
@@ -41,3 +41,8 @@
         background-color: rgba(210, 210, 210, 0.97);
     }
 }
+
+.flex(@value) {
+    -ms-flex: @value; // for IE10
+    flex: @value;
+}

--- a/test/specs/components/header.spec.js
+++ b/test/specs/components/header.spec.js
@@ -5,6 +5,7 @@ import TestUtils from 'react-addons-test-utils';
 import { scryRenderedDOMComponentsWithId, findRenderedDOMComponentsWithId, getContext } from '../../utils/react';
 import * as appService from '../../../src/js/services/app-service';
 import * as appUtils from '../../../src/js/utils/app';
+import { WIDGET_STATE } from '../../../src/js/constants/app';
 import { HeaderComponent } from '../../../src/js/components/header';
 
 import { mockAppStore } from '../../utils/redux';
@@ -15,7 +16,7 @@ const defaultProps = {
     appState: {
         emailCaptureEnabled: false,
         settingsVisible: true,
-        widgetOpened: true,
+        widgetState: WIDGET_STATE.OPENED,
         embedded: false,
         visibleChannelType: false
     },
@@ -57,7 +58,10 @@ describe('Header Component', () => {
         beforeEach(() => {
             props = Object.assign(defaultProps, {});
             mockedStore = mockAppStore(sandbox, {});
-            header = wrapComponentWithContext(HeaderComponent, props, {...context, store: mockedStore});
+            header = wrapComponentWithContext(HeaderComponent, props, {
+                ...context,
+                store: mockedStore
+            });
             headerNode = ReactDOM.findDOMNode(header);
         });
 
@@ -96,7 +100,10 @@ describe('Header Component', () => {
                 }
             });
             mockedStore = mockAppStore(sandbox, {});
-            header = wrapComponentWithContext(HeaderComponent, props, {...context, store: mockedStore});
+            header = wrapComponentWithContext(HeaderComponent, props, {
+                ...context,
+                store: mockedStore
+            });
             headerNode = ReactDOM.findDOMNode(header);
         });
 

--- a/test/specs/components/widget.spec.jsx
+++ b/test/specs/components/widget.spec.jsx
@@ -16,6 +16,7 @@ import { Channel } from '../../../src/js/components/channels/channel';
 import { MessengerButton } from '../../../src/js/components/messenger-button';
 
 import * as appUtils from '../../../src/js/utils/app';
+import { WIDGET_STATE } from '../../../src/js/constants/app';
 
 const sandbox = sinon.sandbox.create();
 
@@ -24,7 +25,7 @@ const defaultProps = {
         email: 'some@email.com'
     },
     appState: {
-        widgetOpened: false,
+        widgetState: WIDGET_STATE.CLOSED,
         settingsVisible: false,
         embedded: false
     },
@@ -109,7 +110,7 @@ describe('Widget Component', () => {
     describe('is opened', () => {
         const props = Object.assign({}, defaultProps, {
             appState: {
-                widgetOpened: true
+                widgetState: WIDGET_STATE.OPENED
             }
         });
         store = createMockedStore(sandbox, props);
@@ -128,7 +129,7 @@ describe('Widget Component', () => {
     describe('conversation view', () => {
         const props = Object.assign({}, defaultProps, {
             appState: {
-                widgetOpened: true
+                widgetState: WIDGET_STATE.OPENED
             }
         });
         store = createMockedStore(sandbox, props);
@@ -157,7 +158,7 @@ describe('Widget Component', () => {
     describe('settings view', () => {
         const props = Object.assign({}, defaultProps, {
             appState: {
-                widgetOpened: true,
+                widgetState: WIDGET_STATE.OPENED,
                 settingsVisible: true
             }
         });

--- a/test/specs/services/app-service.spec.js
+++ b/test/specs/services/app-service.spec.js
@@ -4,6 +4,7 @@ import { openWidget, closeWidget, toggleWidget } from '../../../src/js/services/
 import { mockAppStore } from '../../utils/redux';
 import { OPEN_WIDGET, CLOSE_WIDGET } from '../../../src/js/actions/app-state-actions';
 import { observable } from '../../../src/js/utils/events';
+import { WIDGET_STATE } from '../../../src/js/constants/app';
 
 describe('App Service', () => {
     let mockedStore;
@@ -95,7 +96,7 @@ describe('App Service', () => {
                                 mockedStore = mockAppStore(sandbox, {
                                     appState: {
                                         embedded: isEmbedded,
-                                        widgetOpened: isOpened
+                                        widgetState: isOpened ? WIDGET_STATE.OPENED : WIDGET_STATE.CLOSED
                                     },
                                     conversation: {}
                                 });


### PR DESCRIPTION
Long story short :  since the widget is scaling down to disappear, it was triggering the intro height recalculation, which updated the store, which triggered the conversation component to be updated, which caused the small animation glitch. This will now prevent the intro component to recompute its height when the widget is closed or closing (the widget enters the CLOSED state when starting the animation).

I was also tired by using a boolean to represent 3 possible states, so I made it a proper enum like it should have been from the start.

@alavers @dannytranlx @chloepouprom @spasiu @jugarrit 