### PR TITLE
Add new class for appear and close animation

### DIFF
--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -22,6 +22,7 @@ export const DISABLE_IMAGE_UPLOAD = 'DISABLE_IMAGE_UPLOAD';
 export const SHOW_CHANNEL_PAGE = 'SHOW_CHANNEL_PAGE';
 export const HIDE_CHANNEL_PAGE = 'HIDE_CHANNEL_PAGE';
 export const SET_INTRO_HEIGHT = 'SET_INTRO_HEIGHT';
+export const DISABLE_ANIMATION = 'DISABLE_ANIMATION';
 
 export function toggleWidget() {
     return {
@@ -164,5 +165,11 @@ export function setIntroHeight(value) {
     return {
         type: SET_INTRO_HEIGHT,
         value
+    };
+}
+
+export function disableAnimation() {
+    return {
+        type: DISABLE_ANIMATION
     };
 }

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -77,7 +77,7 @@ export class WidgetComponent extends Component {
     };
 
     componentWillUnmount = () => {
-        window.addEventListener('resize', this.handleResize);
+        window.removeEventListener('resize', this.handleResize);
     };
 
     render() {

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -34,6 +34,10 @@ export class WidgetComponent extends Component {
         ui: PropTypes.object.isRequired
     };
 
+    state = {
+        showAnimation: false
+    };
+
     onTouchStart = (e) => {
         resetUnreadCount();
         // the behavior is problematic only on iOS devices
@@ -50,6 +54,11 @@ export class WidgetComponent extends Component {
 
     onClick = () => {
         resetUnreadCount();
+        this.setState({showAnimation: true});
+    };
+
+    handleResize = () => {
+        this.setState({showAnimation: false});
     };
 
     onWheel = debounce(() => {
@@ -65,6 +74,14 @@ export class WidgetComponent extends Component {
             ui: this.props.ui
         };
     }
+
+    componentDidMount = () => {
+        window.addEventListener('resize', this.handleResize);
+    };
+
+    componentWillUnmount = () => {
+        window.addEventListener('resize', this.handleResize);
+    };
 
     render() {
         const {appState, settings, smoochId} = this.props;
@@ -97,6 +114,10 @@ export class WidgetComponent extends Component {
 
         if (isMobile.apple.device) {
             classNames.push('sk-ios-device');
+        }
+
+        if (this.state.showAnimation) {
+            classNames.push('sk-animation');
         }
 
         const notification = appState.errorNotificationMessage ?

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -18,6 +18,7 @@ import { resetUnreadCount } from '../services/conversation-service';
 import { hasChannels } from '../utils/app';
 import { DISPLAY_STYLE } from '../constants/styles';
 import { WIDGET_STATE } from '../constants/app';
+import { disableAnimation } from '../actions/app-state-actions';
 
 export class WidgetComponent extends Component {
     static propTypes = {
@@ -32,10 +33,6 @@ export class WidgetComponent extends Component {
         app: PropTypes.object.isRequired,
         settings: PropTypes.object.isRequired,
         ui: PropTypes.object.isRequired
-    };
-
-    state = {
-        showAnimation: false
     };
 
     onTouchStart = (e) => {
@@ -54,11 +51,11 @@ export class WidgetComponent extends Component {
 
     onClick = () => {
         resetUnreadCount();
-        this.setState({showAnimation: true});
+
     };
 
     handleResize = () => {
-        this.setState({showAnimation: false});
+        this.props.dispatch(disableAnimation());
     };
 
     onWheel = debounce(() => {
@@ -116,7 +113,7 @@ export class WidgetComponent extends Component {
             classNames.push('sk-ios-device');
         }
 
-        if (this.state.showAnimation) {
+        if (appState.showAnimation) {
             classNames.push('sk-animation');
         }
 
@@ -172,7 +169,7 @@ export class WidgetComponent extends Component {
     }
 }
 
-export const Widget = connect(({appState: {settingsVisible, widgetState, errorNotificationMessage, embedded}, app, ui, user}) => {
+export const Widget = connect(({appState: {settingsVisible, widgetState, errorNotificationMessage, embedded, showAnimation}, app, ui, user}) => {
     // only extract what is needed from appState as this is something that might
     // mutate a lot
     return {
@@ -180,7 +177,8 @@ export const Widget = connect(({appState: {settingsVisible, widgetState, errorNo
             settingsVisible,
             widgetState,
             errorNotificationMessage,
-            embedded
+            embedded,
+            showAnimation
         },
         app,
         settings: app.settings.web,

--- a/src/js/reducers/app-state-reducer.js
+++ b/src/js/reducers/app-state-reducer.js
@@ -16,7 +16,8 @@ const INITIAL_STATE = {
     serverURL: 'https://api.smooch.io/',
     connectNotificationTimestamp: null,
     errorNotificationMessage: null,
-    introHeight: 158
+    introHeight: 158,
+    showAnimation: false
 };
 
 export function AppStateReducer(state = INITIAL_STATE, action) {
@@ -84,13 +85,15 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
             return {
                 ...state,
                 widgetState: state.widgetState === WIDGET_STATE.OPENED ? WIDGET_STATE.CLOSED : WIDGET_STATE.OPENED,
-                settingsVisible: state.settingsVisible && state.widgetState !== WIDGET_STATE.OPENED
+                settingsVisible: state.settingsVisible && state.widgetState !== WIDGET_STATE.OPENED,
+                showAnimation: true
             };
 
         case AppStateActions.OPEN_WIDGET:
             return {
                 ...state,
-                widgetState: WIDGET_STATE.OPENED
+                widgetState: WIDGET_STATE.OPENED,
+                showAnimation: true
             };
 
         case AppStateActions.CLOSE_WIDGET:
@@ -98,7 +101,8 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
                 ...state,
                 visibleChannelType: null,
                 widgetState: WIDGET_STATE.CLOSED,
-                settingsVisible: false
+                settingsVisible: false,
+                showAnimation: true
             };
 
         case AppStateActions.SHOW_SETTINGS:
@@ -166,6 +170,12 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
             return {
                 ...state,
                 introHeight: action.value
+            };
+
+        case AppStateActions.DISABLE_ANIMATION:
+            return {
+                ...state,
+                showAnimation: false
             };
 
         default:

--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -77,46 +77,64 @@
     &.sk-appear {
         bottom: @widget-vertical-spacing;
 
-        animation: sk-appear-tab-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-        animation-delay: .0s;
-        animation-fill-mode: forwards;
-
-        @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
-            animation: sk-appear-tab-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
-        }
-
-        @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-max) {
-            animation: sk-appear-tab-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
-        }
-
-        // Mobile
-        @media (max-width: @screen-xs-max) {
+        @media (max-width: @screen-sm-min) {
             bottom: 0;
-            animation: sk-appear-tab-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
         }
+
+        &.sk-animation {
+            animation: sk-appear-tab-frames-md .4s cubic-bezier(.62, .28, .23, .99);
+            animation-delay: .0s;
+            animation-fill-mode: forwards;
+
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
+                animation: sk-appear-tab-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+            }
+
+            @media (min-width: @screen-sm-min) and (max-height: @screen-xs-ht-max) {
+                animation: sk-appear-tab-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
+            }
+
+            // Mobile
+            @media (max-width: @screen-sm-min) {
+                animation: sk-appear-tab-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
+            }
+        }
+
+        
     }
 
     &.sk-close {
         bottom: @widget-close-bottom-md;
 
-            animation: sk-close-tab-frames-md .4s cubic-bezier(.62, .28, .23, .99);
-            animation-delay: .0s;
-            animation-fill-mode: forwards;
-
         @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
             bottom: @widget-close-bottom-lg;
-            animation: sk-close-tab-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
         }
 
-        @media (min-width: @screen-sm-min) and (max-height: @screen-sm-ht-min) {
+        @media (min-width: @screen-sm-min) and (max-height: @screen-xs-ht-max) {
             bottom: @widget-close-bottom-sm;
-            animation: sk-close-tab-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
         }
 
-        // Mobile
         @media (max-width: @screen-sm-min) {
             bottom: @widget-close-bottom-xs;
-            animation: sk-close-tab-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
+        }
+
+        &.sk-animation {
+                animation: sk-close-tab-frames-md .4s cubic-bezier(.62, .28, .23, .99);
+                animation-delay: .0s;
+                animation-fill-mode: forwards;
+
+            @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
+                animation: sk-close-tab-frames-lg .4s cubic-bezier(.62, .28, .23, .99);
+            }
+
+            @media (min-width: @screen-sm-min) and (max-height: @screen-xs-ht-max) {
+                animation: sk-close-tab-frames-sm .4s cubic-bezier(.62, .28, .23, .99);
+            }
+
+            // Mobile
+            @media (max-width: @screen-sm-min) {
+                animation: sk-close-tab-frames-xs .4s cubic-bezier(.62, .28, .23, .99);
+            }
         }
     }
 

--- a/test/specs/components/widget.spec.jsx
+++ b/test/specs/components/widget.spec.jsx
@@ -27,7 +27,8 @@ const defaultProps = {
     appState: {
         widgetState: WIDGET_STATE.CLOSED,
         settingsVisible: false,
-        embedded: false
+        embedded: false,
+        showAnimation: false
     },
     app: {
         settings: {

--- a/test/specs/reducers/app-state-reducer.spec.js
+++ b/test/specs/reducers/app-state-reducer.spec.js
@@ -1,5 +1,5 @@
 import { AppStateReducer } from '../../../src/js/reducers/app-state-reducer';
-import { TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET } from '../../../src/js/actions/app-state-actions';
+import { TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET, DISABLE_ANIMATION } from '../../../src/js/actions/app-state-actions';
 
 const INITIAL_STATE = AppStateReducer(undefined, {});
 
@@ -7,12 +7,28 @@ describe('App State reducer', () => {
     [TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET].forEach((action) => {
         describe(`${action} action`, () => {
             it('should set the showAnimation flag to true', () => {
-                const beforeState = INITIAL_STATE;
+                const beforeState = {
+                    ...INITIAL_STATE,
+                    showAnimation: false
+                };
                 const afterState = AppStateReducer(beforeState, {
                     type: action
                 });
                 afterState.showAnimation.should.eq(true);
             });
+        });
+    });
+
+    describe('DISABLE_ANIMATION action', () => {
+        it('should set the showAnimation flag to false', () => {
+            const beforeState = {
+                ...INITIAL_STATE,
+                showAnimation: true
+            };
+            const afterState = AppStateReducer(beforeState, {
+                type: DISABLE_ANIMATION
+            });
+            afterState.showAnimation.should.eq(false);
         });
     });
 });

--- a/test/specs/reducers/app-state-reducer.spec.js
+++ b/test/specs/reducers/app-state-reducer.spec.js
@@ -1,0 +1,18 @@
+import { AppStateReducer } from '../../../src/js/reducers/app-state-reducer';
+import { TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET } from '../../../src/js/actions/app-state-actions';
+
+const INITIAL_STATE = AppStateReducer(undefined, {});
+
+describe('App State reducer', () => {
+    [TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET].forEach((action) => {
+        describe(`${action} action`, () => {
+            it('should set the showAnimation flag to true', () => {
+                const beforeState = INITIAL_STATE;
+                const afterState = AppStateReducer(beforeState, {
+                    type: action
+                });
+                afterState.showAnimation.should.eq(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This prevents the widget from opening/closing unnecessarily on window resize. I followed @jpjoyal's proposed approach and disabled the animation on window resize.

The animations are now all in the `sk-animation` class. This class gets added only when clicking on the header (and thus toggling the open/close state). When the window resizes, the class gets removed.

I also fixed a few of the media queries. They should now be consistent with theses media queries: https://github.com/smooch/smooch-js/blob/integration/src/stylesheets/main.less#L40

@lemieux @mspensieri @spasiu @dannytranlx 