### PR TITLE
Fix margins

### DIFF
--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -11,10 +11,6 @@
         height: @conversation-height-mobile;
     }
 
-    &.notification-shown {
-        padding-top: @notification-height;
-    }
-
     .sk-intro-section {
         background-color: #F8F9FA;
         padding: 18px 18px 22px 18px;

--- a/src/stylesheets/notification.less
+++ b/src/stylesheets/notification.less
@@ -5,6 +5,8 @@
     z-index: 1;
 
     .sk-notification {
+        position: absolute;
+        top: 0;
         width: 100%;
         border-top: 1px solid rgba(0, 0, 0, .1);
         background-color: white;
@@ -38,23 +40,5 @@
                 color: white;
             }
         }
-    }
-
-    .sk-notification-enter {
-        height: 0;
-    }
-
-    .sk-notification-enter-active {
-        .transition(height 500ms);
-        height: 100%;
-    }
-
-    .sk-notification-leave {
-        height: 100%;
-    }
-
-    .sk-notification-leave-active {
-        .transition(height 500ms);
-        height: 0;
     }
 }

--- a/src/stylesheets/notification.less
+++ b/src/stylesheets/notification.less
@@ -1,44 +1,34 @@
 .sk-notification-container {
     box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
-    position: absolute;
+    position: relative;
     width: 100%;
     z-index: 1;
 
     .sk-notification {
-        overflow: hidden;
-
-        height: @notification-height;
         width: 100%;
-
-        &.long-text {
-            height: @long-notification-height;
-        }
-
         border-top: 1px solid rgba(0, 0, 0, .1);
         background-color: white;
-        p {
-            margin: 18px 18px;
-            a {
-                color: @sk-blue;
-            }
-            .sk-notification-close {
-                font-size: 20px;
-                font-weight: 600;
+        padding: 12px 12px;
+        a {
+            color: @sk-blue;
+        }
+        .sk-notification-close {
+            font-size: 20px;
+            font-weight: 600;
 
-                position: absolute;
-                top: 0;
-                right: 10px;
+            position: absolute;
+            top: 0;
+            right: 10px;
 
-                display: block;
+            display: block;
 
-                width: 22px;
-                height: 32px;
-                padding-left: 10px;
+            width: 22px;
+            height: 32px;
+            padding-left: 10px;
 
-                text-decoration: none;
+            text-decoration: none;
 
-                color: @sk-dark-grey;
-            }
+            color: @sk-dark-grey;
         }
 
         &.sk-notification-error {
@@ -56,11 +46,11 @@
 
     .sk-notification-enter-active {
         .transition(height 500ms);
-        height: @notification-height;
+        height: 100%;
     }
 
     .sk-notification-leave {
-        height: @notification-height;
+        height: 100%;
     }
 
     .sk-notification-leave-active {

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -71,6 +71,3 @@
 @screen-xs-ht-max: 507px;
 
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
-
-@notification-height: 56px;
-@long-notification-height: 75px;


### PR DESCRIPTION
Single line warnings looked ugly, animations were breaking... So we said **** it, let the notification cover the conversation container.
 
  - Eliminated notification animation
  - Make notification container scale to content
  - Let notification container overlay conversation
  - Reduce padding around notification text from 18px to 12px for all messages

@lemieux @jugarrit @chloepouprom 

WHAT IT LOOKS LIKE:

![screen shot 2016-08-04 at 4 58 05 pm](https://cloud.githubusercontent.com/assets/2235885/17418191/306f0478-5a65-11e6-9062-37c7da1a84e9.png)

![screen shot 2016-08-04 at 4 58 18 pm](https://cloud.githubusercontent.com/assets/2235885/17418192/30746f58-5a65-11e6-85e3-dfeb5e9f1997.png)
