### PR TITLE
Fix embedded mode

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -118,6 +118,7 @@
     @import "reset.less";
     .container();
     height: 100%;
+    position: absolute;
     #sk-wrapper {
         background: @background-color;
         width: 100%;


### PR DESCRIPTION
With `position: absolute`, the element is positioned relative to its first positioned (not static) ancestor element. 🎉 

@lemieux @dannytranlx @mspensieri @Go-Fred 