### PR TITLE
Take full with of container in embedded mode

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -118,6 +118,7 @@
     @import "reset.less";
     .container();
     height: 100%;
+    width: 100%;
     position: absolute;
     #sk-wrapper {
         background: @background-color;


### PR DESCRIPTION
When there are no linkable channels enabled, the widget in embedded mode doesn't take the full width of the container. 😱 This fixes this. 

@lemieux @dannytranlx @spasiu 