### PR TITLE
Fix IE11 button animation

### DIFF
--- a/src/stylesheets/animations.less
+++ b/src/stylesheets/animations.less
@@ -6,7 +6,7 @@
         opacity: 0;
         animation: sk-appear-button-frames .4s cubic-bezier(.62, .28, .23, .99);
         animation-delay: .2s;
-        animation-fill-mode: forwards;
+        animation-fill-mode: both;
 
         @media (max-width: @screen-sm-min) {
             bottom: 0;
@@ -16,7 +16,7 @@
     &.sk-close {
         animation: sk-close-button-frames .4s cubic-bezier(.62, .28, .23, .99);
         animation-delay: .0s;
-        animation-fill-mode: forwards;
+        animation-fill-mode: both;
     }
 
     &.sk-init {
@@ -100,7 +100,7 @@
             }
         }
 
-        
+
     }
 
     &.sk-close {

--- a/src/stylesheets/messenger-button.less
+++ b/src/stylesheets/messenger-button.less
@@ -2,8 +2,6 @@
     position: fixed;
 
     right: @widget-horizontal-spacing;
-    bottom: @widget-vertical-spacing;
-    opacity: 0;
 
     height: @messenger-button-size;
     width: @messenger-button-size;
@@ -16,16 +14,20 @@
     cursor: pointer;
     transform-origin: bottom;
 
+    bottom: @widget-messenger-button-vertical-spacing;
+    opacity: 1;
+    transform: scale(1, 1);
+
     &.messenger-button-shown {
         animation: sk-messenger-button-shown-frames .4s cubic-bezier(.62, .28, .23, .99);
         animation-delay: .2s;
-        animation-fill-mode: forwards;
+        animation-fill-mode: both;
     }
 
     &.messenger-button-hidden {
         animation: sk-messenger-button-hidden-frames .4s cubic-bezier(.62, .28, .23, .99);
         animation-delay: .0s;
-        animation-fill-mode: forwards;
+        animation-fill-mode: both;
     }
 
     .default-icon {


### PR DESCRIPTION
The problem was that after finishing the animation, the button would go back to the 0% keyframe (which hides it) in IE11. Setting animation-fill-mode to `both` fixed that. I tested it IE10, IE11, Chrome, Android and iOS.

@alavers  @chloepouprom @dannytranlx @mspensieri 