### PR TITLE
Fix for wrong isOpened behavior

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -330,7 +330,7 @@ export class Smooch {
     }
 
     isOpened() {
-        return !!store.getState().appState.widgetState === WIDGET_STATE.OPENED;
+        return store.getState().appState.widgetState === WIDGET_STATE.OPENED;
     }
 
     render(container) {


### PR DESCRIPTION
Small fix for the isOpened function. Forgot to remove the `!!` when replacing the boolean with proper states.

I'll merge right away and deploy since this is a pretty small targeted fix.

@chloepouprom @dannytranlx @jugarrit 