### PR TITLE
Force cursor to move to end of input

### DIFF
--- a/src/js/lib/react-telephone-input.jsx
+++ b/src/js/lib/react-telephone-input.jsx
@@ -342,6 +342,7 @@ export class ReactTelephoneInput extends Component {
         this.setState({
             showDropDown: false
         });
+        this._cursorToEnd();
     }
 
     handleFlagItemClick = (country) => {
@@ -389,6 +390,7 @@ export class ReactTelephoneInput extends Component {
         }
 
         this._fillDialCode();
+        this._cursorToEnd();
     }
 
     _fillDialCode() {
@@ -543,6 +545,7 @@ export class ReactTelephoneInput extends Component {
         if (typeof this.props.onBlur === 'function') {
             this.props.onBlur(this.state.formattedNumber, this.state.selectedCountry);
         }
+        this._cursorToEnd(true);
     }
 
     render() {


### PR DESCRIPTION
Gets rid of this:
![img](https://trello-attachments.s3.amazonaws.com/57a9f8b633ee233c19bd20b3/91x55/8ec772fb6fc608dddaecb800f61dd642/upload_8_10_2016_at_11_22_03_AM.png)

@jugarrit @lemieux @dannytranlx @mspensieri 