### PR TITLE
Hide channel icon and name to avoid setting header disappearing

### DIFF
--- a/src/stylesheets/channels.less
+++ b/src/stylesheets/channels.less
@@ -30,7 +30,7 @@
 
     .channel-header {
         .channel-icon, .channel-name {
-            @media (max-height: 400px) {
+            @media (max-height: 400px) and (max-width: @screen-sm-min) {
                 display: none;
             }
         }

--- a/src/stylesheets/channels.less
+++ b/src/stylesheets/channels.less
@@ -29,6 +29,12 @@
     }
 
     .channel-header {
+        .channel-icon, .channel-name {
+            @media (max-height: 400px) {
+                display: none;
+            }
+        }
+
         .channel-icon {
             margin-bottom: 40px;
             height: 65px;


### PR DESCRIPTION
@lemieux @alavers @mspensieri @chloepouprom 

When the phone number input is selected, the window shrinks, causing Chrome for Android to push the header up above the URL bar. Hiding the channel icon and header for extremely small heights fixes this issue.

![image](https://cloud.githubusercontent.com/assets/12450961/17629999/716d877a-608b-11e6-95e2-e5e5bc6654c3.png)
