### PR TITLE
Add pagination in web widget

### DIFF
--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -24,7 +24,7 @@ export const HIDE_CHANNEL_PAGE = 'HIDE_CHANNEL_PAGE';
 export const SET_INTRO_HEIGHT = 'SET_INTRO_HEIGHT';
 export const DISABLE_ANIMATION = 'DISABLE_ANIMATION';
 export const SET_FETCHING_MORE_MESSAGES = 'SET_FETCHING_MORE_MESSAGES';
-export const SET_SCROLL_TO_BOTTOM = 'SET_SCROLL_TO_BOTTOM';
+export const SET_SHOULD_SCROLL_TO_BOTTOM = 'SET_SHOULD_SCROLL_TO_BOTTOM';
 
 export function toggleWidget() {
     return {
@@ -183,9 +183,9 @@ export function setFetchingMoreMessages(value) {
     };
 }
 
-export function setScrollToBottom(value) {
+export function setShouldScrollToBottom(value) {
     return {
-        type: SET_SCROLL_TO_BOTTOM,
+        type: SET_SHOULD_SCROLL_TO_BOTTOM,
         value
     };
 }

--- a/src/js/actions/app-state-actions.js
+++ b/src/js/actions/app-state-actions.js
@@ -23,6 +23,8 @@ export const SHOW_CHANNEL_PAGE = 'SHOW_CHANNEL_PAGE';
 export const HIDE_CHANNEL_PAGE = 'HIDE_CHANNEL_PAGE';
 export const SET_INTRO_HEIGHT = 'SET_INTRO_HEIGHT';
 export const DISABLE_ANIMATION = 'DISABLE_ANIMATION';
+export const SET_FETCHING_MORE_MESSAGES = 'SET_FETCHING_MORE_MESSAGES';
+export const SET_SCROLL_TO_BOTTOM = 'SET_SCROLL_TO_BOTTOM';
 
 export function toggleWidget() {
     return {
@@ -171,5 +173,19 @@ export function setIntroHeight(value) {
 export function disableAnimation() {
     return {
         type: DISABLE_ANIMATION
+    };
+}
+
+export function setFetchingMoreMessages(value) {
+    return {
+        type: SET_FETCHING_MORE_MESSAGES,
+        value
+    };
+}
+
+export function setScrollToBottom(value) {
+    return {
+        type: SET_SCROLL_TO_BOTTOM,
+        value
     };
 }

--- a/src/js/actions/conversation-actions.js
+++ b/src/js/actions/conversation-actions.js
@@ -7,6 +7,7 @@ export const SET_CONVERSATION = 'SET_CONVERSATION';
 export const SET_MESSAGES = 'SET_MESSAGES';
 export const RESET_UNREAD_COUNT = 'RESET_UNREAD_COUNT';
 export const INCREMENT_UNREAD_COUNT = 'INCREMENT_UNREAD_COUNT';
+export const SET_FETCHING_MORE_MESSAGES_FROM_SERVER = 'SET_FETCHING_MORE_MESSAGES_FROM_SERVER';
 
 export function resetConversation() {
     return {
@@ -69,5 +70,12 @@ export function incrementUnreadCount() {
 export function resetUnreadCount() {
     return {
         type: RESET_UNREAD_COUNT
+    };
+}
+
+export function setFetchingMoreMessagesFromServer(value) {
+    return {
+        type: SET_FETCHING_MORE_MESSAGES_FROM_SERVER,
+        value
     };
 }

--- a/src/js/actions/conversation-actions.js
+++ b/src/js/actions/conversation-actions.js
@@ -1,8 +1,10 @@
 export const ADD_MESSAGE = 'ADD_MESSAGE';
+export const ADD_MESSAGES = 'ADD_MESSAGES';
 export const REPLACE_MESSAGE = 'REPLACE_MESSAGE';
 export const REMOVE_MESSAGE = 'REMOVE_MESSAGE';
 export const RESET_CONVERSATION = 'RESET_CONVERSATION';
 export const SET_CONVERSATION = 'SET_CONVERSATION';
+export const SET_MESSAGES = 'SET_MESSAGES';
 export const RESET_UNREAD_COUNT = 'RESET_UNREAD_COUNT';
 export const INCREMENT_UNREAD_COUNT = 'INCREMENT_UNREAD_COUNT';
 
@@ -19,12 +21,27 @@ export function setConversation(props) {
     };
 }
 
+export function setMessages(messages) {
+    return {
+        type: SET_MESSAGES,
+        messages
+    };
+}
+
 export function addMessage(props) {
     return {
         type: ADD_MESSAGE,
         message: Object.assign({
             actions: []
         }, props)
+    };
+}
+
+export function addMessages(messages, append = true) {
+    return {
+        type: ADD_MESSAGES,
+        messages,
+        append
     };
 }
 

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -70,9 +70,10 @@ export class ConversationComponent extends Component {
 
         // If top of Conversation component is reached, we need to fetch older messages
         const node = findDOMNode(this);
-        if(node.scrollTop === 0) {
+        if (node.scrollTop === 0) {
             this.fetchHistory();
-        } else if(shouldScrollToBottom) {
+        } else if (shouldScrollToBottom) {
+            // Once we've started scrolling, we don't want the default behavior to force the scroll to the bottom afterwards
             dispatch(setShouldScrollToBottom(false));
         }
     };
@@ -81,7 +82,7 @@ export class ConversationComponent extends Component {
         const {dispatch, hasMoreMessages, isFetchingMoreMessages, messages} = this.props;
 
         const node = findDOMNode(this);
-        if(hasMoreMessages && !isFetchingMoreMessages) {
+        if (hasMoreMessages && !isFetchingMoreMessages) {
             // make sure the last message is one from the server, otherwise it doesn't need to scroll to previous first message
             if (messages.length > 0 && messages[messages.length - 1]._id) {
                 this._lastTopMessageId = messages[0]._id;
@@ -113,7 +114,7 @@ export class ConversationComponent extends Component {
     };
 
     scrollToPreviousFirstMessage = () => {
-        if(this._lastTopMessageNodePosition && !this._isScrolling) {
+        if (this._lastTopMessageNodePosition && !this._isScrolling) {
             const container = findDOMNode(this);
             const node = this._lastTopMessageNode;
             this._isScrolling = true;
@@ -139,8 +140,8 @@ export class ConversationComponent extends Component {
             this._forceScrollToBottom = true;
         }
 
-        // Check for new appMaker messages
-        const isAppMakerMessage = newMessages.length - currentMessages.length === 1 ? newMessages.slice(-1)[0].role === 'appMaker' : false;
+        // Check for new appMaker (and whisper) messages
+        const isAppMakerMessage = newMessages.length - currentMessages.length === 1 ? newMessages.slice(-1)[0].role !== 'appUser' : false;
         if (isAppMakerMessage && !isFetchingMoreMessages) {
             const container = findDOMNode(this);
             const appMakerMessageBottom = this._lastMessageNode.getBoundingClientRect().bottom;
@@ -172,14 +173,6 @@ export class ConversationComponent extends Component {
 
     componentWillUnmount() {
         this.scrollTimeouts.forEach(clearTimeout);
-        delete this._lastTopMessageNode;
-        delete this._lastTopMessageId;
-        delete this._lastTopMessageNodePosition;
-        delete this._topMessageNode;
-        delete this._forceScrollToBottom;
-        delete this._isScrolling;
-        delete this._lastMessageNode;
-        delete this._lastMessageId;
     }
 
     render() {

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -75,10 +75,15 @@ export class ConversationComponent extends Component {
     };
 
     fetchHistory = () => {
-        const {dispatch, hasMoreMessages, isFetchingMoreMessages} = this.props;
+        const {dispatch, hasMoreMessages, isFetchingMoreMessages, messages} = this.props;
 
         const node = findDOMNode(this);
         if(hasMoreMessages && !isFetchingMoreMessages) {
+            // make sure the last message is one from the server, otherwise it doesn't need to scroll to previous first message
+            if (messages.length > 0 && messages[messages.length - 1]._id) {
+                this._lastTopMessageId = messages[0]._id;
+            }
+            
             const top = getTop(this._topMessageNode, node);
             this._lastTopMessageNodePosition = top - node.scrollTop;
             dispatch(setFetchingMoreMessages(true));
@@ -108,7 +113,6 @@ export class ConversationComponent extends Component {
         if(this._lastTopMessageNodePosition && !this._isScrolling) {
             const container = findDOMNode(this);
             const node = this._lastTopMessageNode;
-            delete this._lastTopMessageId;
 
             this._isScrolling = true;
 
@@ -135,7 +139,7 @@ export class ConversationComponent extends Component {
     }
 
     componentDidUpdate() {
-        if (this._lastTopMessageId) {
+        if (this._lastTopMessageNode) {
             this.scrollToPreviousFirstMessage();
         } else {
             this.scrollToBottom();
@@ -155,6 +159,10 @@ export class ConversationComponent extends Component {
             const refCallback = (c) => {
                 if (index === 0) {
                     this._topMessageNode = findDOMNode(c);
+                }
+
+                if (this._lastTopMessageId === message._id) {
+                    this._lastTopMessageNode = findDOMNode(c);
                 }
             };
 

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -70,6 +70,7 @@ export class ConversationComponent extends Component {
 
         // If top of Conversation component is reached, we need to fetch older messages
         const node = findDOMNode(this);
+        console.log(node.scrollTop);
         if (node.scrollTop === 0) {
             this.fetchHistory();
         } else if (shouldScrollToBottom) {
@@ -221,7 +222,7 @@ export class ConversationComponent extends Component {
         } : undefined;
 
         const messagesContainerStyle = {
-            maxHeight: `calc(100% - ${introHeight + INTRO_BOTTOM_SPACER}px)`
+            maxHeight: hasMoreMessages ? '100%' : `calc(100% - ${introHeight + INTRO_BOTTOM_SPACER}px)`
         };
 
         let retrieveHistory;
@@ -245,12 +246,14 @@ export class ConversationComponent extends Component {
             }
         }
 
+        const introduction = hasMoreMessages ? '' : <Introduction/>;
+
         return <div id='sk-conversation'
                     className={ errorNotificationMessage && 'notification-shown' }
                     ref='container'
                     onTouchMove={ this.onTouchMove }
                     onScroll={ isMobile.any ? this.onScroll : this.debounceOnScroll }>
-                   <Introduction/>
+                   { introduction }
                    <div ref='messagesContainer'
                         className='sk-messages-container'
                         style={ messagesContainerStyle }>

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -118,7 +118,7 @@ export class ConversationComponent extends Component {
 
             this._isScrolling = true;
             container.scrollTop = getTop(node, container) - this._lastTopMessageNodePosition;
-            
+
             const timeout = setTimeout(() => {
                 this._isScrolling = false;
             });

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -117,9 +117,9 @@ export class ConversationComponent extends Component {
             const node = this._lastTopMessageNode;
 
             this._isScrolling = true;
-
+            container.scrollTop = getTop(node, container) - this._lastTopMessageNodePosition;
+            
             const timeout = setTimeout(() => {
-                container.scrollTop = getTop(node, container) - this._lastTopMessageNodePosition;
                 this._isScrolling = false;
             });
 

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -68,6 +68,7 @@ export class ConversationComponent extends Component {
     onScroll = () => {
         const {dispatch, shouldScrollToBottom} = this.props;
 
+        // If top of Conversation component is reached, we need to fetch older messages
         const node = findDOMNode(this);
         if(node.scrollTop === 0) {
             this.fetchHistory();
@@ -115,8 +116,10 @@ export class ConversationComponent extends Component {
         if(this._lastTopMessageNodePosition && !this._isScrolling) {
             const container = findDOMNode(this);
             const node = this._lastTopMessageNode;
-
             this._isScrolling = true;
+
+            // When fetching more messages, we want to make sure that after 
+            // render, the messages stay in the same places
             container.scrollTop = getTop(node, container) - this._lastTopMessageNodePosition;
 
             const timeout = setTimeout(() => {
@@ -143,7 +146,8 @@ export class ConversationComponent extends Component {
             const appMakerMessageBottom = this._lastMessageNode.getBoundingClientRect().bottom;
             const containerBottom = container.getBoundingClientRect().bottom;
 
-            // If appMaker message is 'in view', we should scroll to bottom
+            // If appMaker message is 'in view', we should scroll to bottom.
+            // Otherwise, don't scroll
             if (appMakerMessageBottom <= containerBottom) {
                 this._forceScrollToBottom = true;
             } else {
@@ -153,6 +157,8 @@ export class ConversationComponent extends Component {
     }
 
     componentDidMount() {
+        // On component render, force scroll to bottom, or else conversation will
+        // find itself at a random spot
         this.scrollToBottom();
     }
 
@@ -216,7 +222,6 @@ export class ConversationComponent extends Component {
                 messageItems.push(<ConnectNotification key='connect-notification' />);
             }
         }
-
 
         const logoStyle = isMobile.apple.device ? {
             paddingBottom: 10

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -11,6 +11,7 @@ import { Introduction } from './introduction';
 import { setShouldScrollToBottom, setFetchingMoreMessages } from '../actions/app-state-actions';
 import { fetchMoreMessages } from '../services/conversation-service';
 import { getTop } from '../utils/dom';
+import debounce from 'lodash.debounce';
 
 const INTRO_BOTTOM_SPACER = 10;
 
@@ -26,6 +27,11 @@ export class ConversationComponent extends Component {
         messages: PropTypes.array.isRequired,
         errorNotificationMessage: PropTypes.string
     };
+
+    constructor(...args) {
+        super(...args);
+        this.debounceOnScroll = debounce(this.onScroll.bind(this), 200);
+    }
 
     scrollTimeouts = [];
 
@@ -60,18 +66,14 @@ export class ConversationComponent extends Component {
     };
 
     onScroll = () => {
-        // HINT: might want to consider debouncing or throttling this since it would be executed a lot on scroll
         const {dispatch, shouldScrollToBottom} = this.props;
 
         const node = findDOMNode(this);
         if(node.scrollTop === 0) {
             this.fetchHistory();
         } else if(shouldScrollToBottom) {
-            // HINT : this will be triggered when an appMaker message is added, which is probably why it's not scrolling to bottom when receiving one
             dispatch(setShouldScrollToBottom(false));
         }
-
-        // HINT: might want to check if scroll is at the bottom to reactivate auto scrolling
     };
 
     fetchHistory = () => {
@@ -221,7 +223,7 @@ export class ConversationComponent extends Component {
                     className={ errorNotificationMessage && 'notification-shown' }
                     ref='container'
                     onTouchMove={ this.onTouchMove }
-                    onScroll={ this.onScroll }>
+                    onScroll={ isMobile.any ? this.onScroll : this.debounceOnScroll }>
                    <Introduction/>
                    <div ref='messagesContainer'
                         className='sk-messages-container'

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -26,7 +26,7 @@ export class IntroductionComponent extends Component {
 
     constructor(...args) {
         super(...args);
-        this._debounceHeightCalculation = debounce(this.calculateIntroHeight.bind(this), 150);
+        this._debounceHeightCalculation = debounce(this.calculateIntroHeight.bind(this), 400);
     }
 
     componentDidMount() {

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import debounce from 'lodash.debounce';
 import { findDOMNode } from 'react-dom';
 
 import { AlternateChannels } from './alternate-channels';
@@ -25,11 +24,11 @@ export class IntroductionComponent extends Component {
 
     constructor(...args) {
         super(...args);
-        this._debounceHeightCalculation = debounce(this.calculateIntroHeight.bind(this), 400);
     }
 
     componentDidMount() {
-        // Make sure Introduction Component has fully rendered before computing height
+        // Height of Introduction component will be computed on render and on resize only
+        // Make sure Introduction component has fully rendered before computing height
         setTimeout(() => {
             this.calculateIntroHeight();
         }, 200);

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -10,7 +10,6 @@ import { setIntroHeight } from '../actions/app-state-actions';
 
 import { createMarkup } from '../utils/html';
 import { getAppChannelDetails } from '../utils/app';
-import { WIDGET_STATE } from '../constants/app';
 
 export class IntroductionComponent extends Component {
     static propTypes = {
@@ -30,31 +29,27 @@ export class IntroductionComponent extends Component {
     }
 
     componentDidMount() {
-        setTimeout(() => this.calculateIntroHeight());
-        window.addEventListener('resize', this._debounceHeightCalculation);
-    }
+        // Make sure Introduction Component has fully rendered before computing height
+        setTimeout(() => {
+            this.calculateIntroHeight();
+        }, 200);
 
-    componentWillUpdate() {
-        this._debounceHeightCalculation();
+        window.addEventListener('resize', () => {
+            this.calculateIntroHeight();
+        });
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this._debounceHeightCalculation);
+        window.removeEventListener('resize', this.calculateIntroHeight());
     }
 
     calculateIntroHeight() {
-        const {appState: {introHeight, widgetState}, dispatch} = this.props;
+        const {appState: {introHeight}, dispatch} = this.props;
+        const node = findDOMNode(this.refs.introductionContainer);
+        const nodeHeight = node.offsetHeight;
 
-        // don't recalculate height if widget is closed or closing
-        if (widgetState === WIDGET_STATE.OPENED) {
-            const node = findDOMNode(this);
-
-            const nodeRect = node.getBoundingClientRect();
-            const nodeHeight = Math.floor(nodeRect.height);
-
-            if (introHeight !== nodeHeight) {
-                dispatch(setIntroHeight(nodeHeight));
-            }
+        if (introHeight !== nodeHeight) {
+            dispatch(setIntroHeight(nodeHeight));
         }
     }
 
@@ -65,7 +60,8 @@ export class IntroductionComponent extends Component {
         const channelsAvailable = channelDetailsList.length > 0;
         const introText = channelsAvailable ? `${text.introductionText} ${text.introAppText}` : text.introductionText;
 
-        return <div className='sk-intro-section'>
+        return <div className='sk-intro-section'
+                    ref='introductionContainer'>
                    { app.iconUrl ? <img className='app-icon'
                                         src={ app.iconUrl } />
                          : <DefaultAppIcon /> }

--- a/src/js/reducers/app-state-reducer.js
+++ b/src/js/reducers/app-state-reducer.js
@@ -17,7 +17,9 @@ const INITIAL_STATE = {
     connectNotificationTimestamp: null,
     errorNotificationMessage: null,
     introHeight: 158,
-    showAnimation: false
+    showAnimation: false,
+    isFetchingMoreMessages: false,
+    scrollToBottom: true
 };
 
 export function AppStateReducer(state = INITIAL_STATE, action) {
@@ -176,6 +178,17 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
             return {
                 ...state,
                 showAnimation: false
+            };
+
+        case AppStateActions.SET_FETCHING_MORE_MESSAGES:
+            return {
+                ...state,
+                isFetchingMoreMessages: action.value
+            };
+        case AppStateActions.SET_SCROLL_TO_BOTTOM:
+            return {
+                ...state,
+                scrollToBottom: action.value
             };
 
         default:

--- a/src/js/reducers/app-state-reducer.js
+++ b/src/js/reducers/app-state-reducer.js
@@ -19,7 +19,7 @@ const INITIAL_STATE = {
     introHeight: 158,
     showAnimation: false,
     isFetchingMoreMessages: false,
-    scrollToBottom: true
+    shouldScrollToBottom: true
 };
 
 export function AppStateReducer(state = INITIAL_STATE, action) {
@@ -185,10 +185,10 @@ export function AppStateReducer(state = INITIAL_STATE, action) {
                 ...state,
                 isFetchingMoreMessages: action.value
             };
-        case AppStateActions.SET_SCROLL_TO_BOTTOM:
+        case AppStateActions.SET_SHOULD_SCROLL_TO_BOTTOM:
             return {
                 ...state,
-                scrollToBottom: action.value
+                shouldScrollToBottom: action.value
             };
 
         default:

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -3,7 +3,8 @@ import { RESET } from '../actions/common-actions';
 
 const INITIAL_STATE = {
     messages: [],
-    unreadCount: 0
+    unreadCount: 0,
+    hasMoreMessages: false
 };
 
 const sortMessages = (messages) => messages.sort((messageA, messageB) => {
@@ -116,7 +117,8 @@ export function ConversationReducer(state = INITIAL_STATE, action) {
             };
         case ConversationActions.SET_CONVERSATION:
             return {
-                ...action.conversation
+                ...action.conversation,
+                messages: state.messages
             };
         case ConversationActions.SET_MESSAGES:
             return {

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -87,20 +87,20 @@ const assignGroups = (messages) => {
         const author = message.role === 'appUser' ? message.role : message.name;
 
         if (!lastAuthor) {
-                lastAuthor = author;
-                message.firstInGroup = true;
-                message.lastInGroup = true;
-            }
+            lastAuthor = author;
+            message.firstInGroup = true;
+            message.lastInGroup = true;
+        }
 
         if (lastAuthor === author) {
-                if (index > 0) {
-                   messages[index - 1].lastInGroup = false;
-                   message.lastInGroup = true;
-                }
-            } else {
-                message.firstInGroup = true;
+            if (index > 0) {
+                messages[index - 1].lastInGroup = false;
                 message.lastInGroup = true;
             }
+        } else {
+            message.firstInGroup = true;
+            message.lastInGroup = true;
+        }
 
         lastAuthor = author;
     });
@@ -111,11 +111,26 @@ export function ConversationReducer(state = INITIAL_STATE, action) {
     switch (action.type) {
         case RESET:
         case ConversationActions.RESET_CONVERSATION:
-            return Object.assign({}, INITIAL_STATE);
+            return {
+                ...INITIAL_STATE
+            };
         case ConversationActions.SET_CONVERSATION:
-            return Object.assign({}, action.conversation, {
-                messages: assignGroups(sortMessages(removeDuplicates(action.conversation.messages)))
-            });
+            return {
+                ...action.conversation
+            };
+        case ConversationActions.SET_MESSAGES:
+            return {
+                ...state,
+                messages: assignGroups(sortMessages(removeDuplicates(action.messages)))
+            };
+        case ConversationActions.ADD_MESSAGES:
+            return {
+                ...state,
+                messages: assignGroups(sortMessages(removeDuplicates(action.append ?
+                    [...state.messages, ...action.messages] :
+                    [...action.messages, ...state.messages]
+                )))
+            };
         case ConversationActions.ADD_MESSAGE:
             return Object.assign({}, state, {
                 messages: addMessage(state.messages, action.message)

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -4,7 +4,8 @@ import { RESET } from '../actions/common-actions';
 const INITIAL_STATE = {
     messages: [],
     unreadCount: 0,
-    hasMoreMessages: false
+    hasMoreMessages: false,
+    isFetchingMoreMessagesFromServer: false
 };
 
 const sortMessages = (messages) => messages.sort((messageA, messageB) => {
@@ -152,6 +153,10 @@ export function ConversationReducer(state = INITIAL_STATE, action) {
         case ConversationActions.RESET_UNREAD_COUNT:
             return Object.assign({}, state, {
                 unreadCount: 0
+            });
+        case ConversationActions.SET_FETCHING_MORE_MESSAGES_FROM_SERVER:
+            return Object.assign({}, state, {
+                isFetchingMoreMessagesFromServer: action.value
             });
         default:
             return state;

--- a/src/js/reducers/ui-reducer.js
+++ b/src/js/reducers/ui-reducer.js
@@ -46,7 +46,8 @@ const INITIAL_STATE = {
         smsChangeNumber: 'Change my number',
         smsSendText: 'Send me a text',
         smsContinue: 'Continue',
-        smsCancel: 'Cancel'
+        smsCancel: 'Cancel',
+        fetchingHistory: 'Retrieving history...'
     }
 };
 

--- a/src/js/reducers/ui-reducer.js
+++ b/src/js/reducers/ui-reducer.js
@@ -47,7 +47,8 @@ const INITIAL_STATE = {
         smsSendText: 'Send me a text',
         smsContinue: 'Continue',
         smsCancel: 'Cancel',
-        fetchingHistory: 'Retrieving history...'
+        fetchingHistory: 'Retrieving history...',
+        fetchHistory: 'Load more'
     }
 };
 

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -2,7 +2,7 @@ import { store } from '../stores/app-store';
 import { showConnectNotification } from '../services/app-service';
 import { addMessage, addMessages, replaceMessage, removeMessage, setConversation, resetUnreadCount as resetUnreadCountAction, setMessages } from '../actions/conversation-actions';
 import { updateUser } from '../actions/user-actions';
-import { showErrorNotification } from '../actions/app-state-actions';
+import { showErrorNotification, setFetchingMoreMessages, setScrollToBottom } from '../actions/app-state-actions';
 import { unsetFayeSubscriptions } from '../actions/faye-actions';
 import { core } from './core';
 import { immediateUpdate } from './user-service';
@@ -53,10 +53,16 @@ export function handleConnectNotification(response) {
 export function sendChain(sendFn) {
     const promise = immediateUpdate(store.getState().user);
 
+    const enableScrollToBottom = (response) => {
+        store.dispatch(setScrollToBottom(true));
+        return response;
+    };
+
     if (store.getState().user.conversationStarted) {
         return promise
             .then(connectFayeConversation)
             .then(sendFn)
+            .then(enableScrollToBottom)
             .then(handleConnectNotification);
     }
 
@@ -64,6 +70,7 @@ export function sendChain(sendFn) {
     // then get it and connect faye
     return promise
         .then(sendFn)
+        .then(enableScrollToBottom)
         .then(handleConnectNotification)
         .then(connectFayeConversation);
 }
@@ -161,9 +168,12 @@ export function uploadImage(file) {
     });
 }
 
-export function getConversation() {
+export function getMessages() {
     return core().appUsers.getMessages(getUserId()).then((response) => {
-        store.dispatch(setConversation(response.conversation));
+        store.dispatch(setConversation({
+            ...response.conversation,
+            hasMoreMessages: !!response.previous
+        }));
         store.dispatch(setMessages(response.messages));
         return response;
     });
@@ -220,7 +230,7 @@ export function handleConversationUpdated() {
     const {faye: {conversationSubscription}} = store.getState();
 
     if (!conversationSubscription) {
-        return getConversation()
+        return getMessages()
             .then((response) => {
                 return connectFayeConversation().then(() => {
                     return response;
@@ -234,5 +244,29 @@ export function handleConversationUpdated() {
 export function postPostback(actionId) {
     return core().conversations.postPostback(getUserId(), actionId).catch(() => {
         store.dispatch(showErrorNotification(store.getState().ui.text.actionPostbackError));
+    });
+}
+
+
+export function fetchMoreMessages() {
+    const {conversation: {hasMoreMessages, messages}, appState: {isFetchingMoreMessages}} = store.getState();
+
+    if (isFetchingMoreMessages || !hasMoreMessages) {
+        return Promise.resolve();
+    }
+
+    const id = messages[0]._id;
+    store.dispatch(setFetchingMoreMessages(true));
+    return core().appUsers.getMessages(getUserId(), {
+        before: id
+    }).then((response) => {
+        store.dispatch(setConversation({
+            ...response.conversation,
+            hasMoreMessages: !!response.previous
+        }));
+
+        store.dispatch(addMessages(response.messages, false));
+        store.dispatch(setFetchingMoreMessages(false));
+        return response;
     });
 }

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -1,6 +1,6 @@
 import { store } from '../stores/app-store';
 import { showConnectNotification } from '../services/app-service';
-import { addMessage, replaceMessage, removeMessage, setConversation, resetUnreadCount as resetUnreadCountAction } from '../actions/conversation-actions';
+import { addMessage, addMessages, replaceMessage, removeMessage, setConversation, resetUnreadCount as resetUnreadCountAction, setMessages } from '../actions/conversation-actions';
 import { updateUser } from '../actions/user-actions';
 import { showErrorNotification } from '../actions/app-state-actions';
 import { unsetFayeSubscriptions } from '../actions/faye-actions';
@@ -162,8 +162,9 @@ export function uploadImage(file) {
 }
 
 export function getConversation() {
-    return core().conversations.get(getUserId()).then((response) => {
+    return core().appUsers.getMessages(getUserId()).then((response) => {
         store.dispatch(setConversation(response.conversation));
+        store.dispatch(setMessages(response.messages));
         return response;
     });
 }

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -2,7 +2,7 @@ import { store } from '../stores/app-store';
 import { showConnectNotification } from '../services/app-service';
 import { addMessage, addMessages, replaceMessage, removeMessage, setConversation, resetUnreadCount as resetUnreadCountAction, setMessages } from '../actions/conversation-actions';
 import { updateUser } from '../actions/user-actions';
-import { showErrorNotification, setFetchingMoreMessages, setScrollToBottom } from '../actions/app-state-actions';
+import { showErrorNotification, setFetchingMoreMessages, setShouldScrollToBottom } from '../actions/app-state-actions';
 import { unsetFayeSubscriptions } from '../actions/faye-actions';
 import { core } from './core';
 import { immediateUpdate } from './user-service';
@@ -54,7 +54,7 @@ export function sendChain(sendFn) {
     const promise = immediateUpdate(store.getState().user);
 
     const enableScrollToBottom = (response) => {
-        store.dispatch(setScrollToBottom(true));
+        store.dispatch(setShouldScrollToBottom(true));
         return response;
     };
 
@@ -249,9 +249,10 @@ export function postPostback(actionId) {
 
 
 export function fetchMoreMessages() {
-    const {conversation: {hasMoreMessages, messages}, appState: {isFetchingMoreMessages}} = store.getState();
+    const {conversation: {hasMoreMessages, messages}} = store.getState();
 
-    if (isFetchingMoreMessages || !hasMoreMessages) {
+    // TODO : add independent guard against parallel fetching
+    if (!hasMoreMessages) {
         return Promise.resolve();
     }
 

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -17,7 +17,7 @@ import { openWidget, closeWidget, hideSettings, hideChannelPage } from './servic
 import { login } from './services/auth-service';
 import { getAccount } from './services/stripe-service';
 import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, updateNowViewing, immediateUpdate as immediateUpdateUser } from './services/user-service';
-import { getConversation, sendMessage, connectFayeConversation, disconnectFaye, handleConversationUpdated } from './services/conversation-service';
+import { sendMessage, disconnectFaye, handleConversationUpdated } from './services/conversation-service';
 
 import { observable, observeStore } from './utils/events';
 import { waitForPage, monitorUrlChanges, stopMonitoringUrlChanges, monitorBrowserState, stopMonitoringBrowserState } from './utils/dom';
@@ -238,7 +238,7 @@ export class Smooch {
             return immediateUpdateUser(attributes).then(() => {
                 const user = store.getState().user;
                 if (user.conversationStarted) {
-                    return getConversation().then(connectFayeConversation);
+                    return handleConversationUpdated();
                 }
             });
         }).then(() => {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -102,3 +102,15 @@ export function getElementProperties(element) {
         fontSize: style.getPropertyValue('font-size')
     };
 }
+
+export function getTop(node, container = document.body) {
+    let top = 0;
+    if (node.offsetParent) {
+        do {
+            top += node.offsetTop;
+            node = node.offsetParent;
+        } while (node && node !== container);
+
+        return top;
+    }
+}

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -105,7 +105,7 @@ export function getElementProperties(element) {
 
 export function getTop(node, container = document.body) {
     let top = 0;
-    if (node.offsetParent) {
+    if (node && node.offsetParent) {
         do {
             top += node.offsetTop;
             node = node.offsetParent;

--- a/src/js/utils/faye.js
+++ b/src/js/utils/faye.js
@@ -5,7 +5,7 @@ import { store } from '../stores/app-store';
 import { setUser } from '../actions/user-actions';
 import { setFayeConversationSubscription, setFayeUserSubscription } from '../actions/faye-actions';
 import { addMessage, incrementUnreadCount, resetUnreadCount } from '../actions/conversation-actions';
-import { getConversation, disconnectFaye, handleConversationUpdated } from '../services/conversation-service';
+import { getMessages, disconnectFaye, handleConversationUpdated } from '../services/conversation-service';
 import { showSettings, hideChannelPage, hideConnectNotification } from '../services/app-service';
 import { getDeviceId } from './device';
 import { ANIMATION_TIMINGS } from '../constants/styles';
@@ -43,7 +43,7 @@ export function getClient() {
             const {user} = store.getState();
 
             if (user.conversationStarted) {
-                getConversation();
+                getMessages();
             }
         });
     }
@@ -95,7 +95,7 @@ export function updateUser(currentAppUser, nextAppUser) {
         if (currentAppUser.conversationStarted) {
             // if the conversation is already started,
             // fetch the conversation for merged messages
-            getConversation();
+            getMessages();
         } else if (nextAppUser.conversationStarted) {
             // if the conversation wasn't already started,
             // `handleConversationUpdated` will connect faye and fetch it

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -73,6 +73,8 @@
         text-align: center;
         font-style: italic;
         color: @sk-medium-grey;
+        padding-top: 5px;
+        padding-bottom: 5px;
     }
 
     .sk-messages {

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -67,6 +67,13 @@
         max-height: 100%;
     }
 
+    .sk-fetch-history {
+        width: 100%;
+        text-align: center;
+        font-style: italic;
+        color: @sk-medium-grey;
+    }
+
     .sk-messages {
         padding: 0 15px 0 5px;
     }

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -19,6 +19,7 @@
         background-color: #F8F9FA;
         padding: 18px 18px 22px 18px;
         border-bottom: solid 1px #E6E6E6;
+        min-height: 158px;
 
         .app-name {
             color: #464646;

--- a/test/mocks/core.js
+++ b/test/mocks/core.js
@@ -10,7 +10,8 @@ export function createMock(sinon) {
             updateDevice: sinon.stub(),
             linkChannel: sinon.stub(),
             unlinkChannel: sinon.stub(),
-            pingChannel: sinon.stub()
+            pingChannel: sinon.stub(),
+            getMessages: sinon.stub()
         },
 
         conversations: {

--- a/test/specs/components/conversation.spec.js
+++ b/test/specs/components/conversation.spec.js
@@ -52,7 +52,13 @@ describe('Conversation Component', () => {
 
         mockedStore = mockAppStore(sandbox, {});
         context = getContext({
-            store: mockedStore
+            store: mockedStore,
+            ui: {
+                text: {
+                    fetchingHistory: 'fetching-history',
+                    fetchHistory: 'fetch-history'
+                }
+            }
         });
     });
 

--- a/test/specs/components/conversation.spec.js
+++ b/test/specs/components/conversation.spec.js
@@ -29,7 +29,8 @@ const defaultProps = {
             received: 4
         }
     ],
-    introHeight: 100
+    introHeight: 100,
+    hasMoreMessages: false
 };
 
 describe('Conversation Component', () => {
@@ -91,6 +92,20 @@ describe('Conversation Component', () => {
 
         it('should render', () => {
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedConnectNotification').length.should.eq(1);
+        });
+    });
+
+    describe('Introduction component', () => {
+        [true, false].forEach((hasMoreMessages) => {
+            describe(`${hasMoreMessages ? '' : 'no'} more messages to fetch`, () => {
+                it(`should ${hasMoreMessages ? 'not' : ''} render`, () => {
+                    const props = Object.assign(defaultProps, {
+                        hasMoreMessages: hasMoreMessages
+                    });
+                    component = wrapComponentWithContext(ConversationComponent, props, context);
+                    TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedIntroduction').length.should.eq(hasMoreMessages ? 0 : 1);
+                });
+            });
         });
     });
 });

--- a/test/specs/reducers/app-state-reducer.spec.js
+++ b/test/specs/reducers/app-state-reducer.spec.js
@@ -1,5 +1,5 @@
 import { AppStateReducer } from '../../../src/js/reducers/app-state-reducer';
-import { TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET, DISABLE_ANIMATION } from '../../../src/js/actions/app-state-actions';
+import { TOGGLE_WIDGET, OPEN_WIDGET, CLOSE_WIDGET, DISABLE_ANIMATION, SET_FETCHING_MORE_MESSAGES, SET_SHOULD_SCROLL_TO_BOTTOM } from '../../../src/js/actions/app-state-actions';
 
 const INITIAL_STATE = AppStateReducer(undefined, {});
 
@@ -29,6 +29,30 @@ describe('App State reducer', () => {
                 type: DISABLE_ANIMATION
             });
             afterState.showAnimation.should.eq(false);
+        });
+    });
+
+    describe('SET_FETCHING_MORE_MESSAGES action', () => {
+        it('should set the isFetchingMoreMessages flag', () => {
+            const beforeState = INITIAL_STATE;
+            const afterState = AppStateReducer(beforeState, {
+                type: SET_FETCHING_MORE_MESSAGES,
+                value: true
+            });
+            beforeState.isFetchingMoreMessages.should.eq(false);
+            afterState.isFetchingMoreMessages.should.eq(true);
+        });
+    });
+
+    describe('SET_SHOULD_SCROLL_TO_BOTTOM action', () => {
+        it('should set the shouldScrollToBottom flag', () => {
+            const beforeState = INITIAL_STATE;
+            const afterState = AppStateReducer(beforeState, {
+                type: SET_SHOULD_SCROLL_TO_BOTTOM,
+                value: false
+            });
+            beforeState.shouldScrollToBottom.should.eq(true);
+            afterState.shouldScrollToBottom.should.eq(false);
         });
     });
 });

--- a/test/specs/reducers/conversation-reducer.spec.js
+++ b/test/specs/reducers/conversation-reducer.spec.js
@@ -105,14 +105,12 @@ describe('Conversation reducer', () => {
 
     describe('SET_CONVERSATION action', () => {
         it('should set state conversation with messages from action', () => {
-            const beforeState = INITIAL_STATE;
+            const beforeState = {
+                messages: MESSAGES
+            };
             const afterState = ConversationReducer(beforeState, {
                 type: SET_CONVERSATION,
-                conversation: {
-                    messages: MESSAGES,
-                    appUsers: [],
-                    appMakers: []
-                }
+                conversation: {}
             });
             afterState.messages.length.should.eq(2);
             afterState.messages.should.contain(MESSAGE_1);
@@ -142,7 +140,8 @@ describe('Conversation reducer', () => {
             const beforeState = INITIAL_STATE;
             const afterState = {
                 messages: [MESSAGE_FROM_APP_USER],
-                unreadCount: 0
+                unreadCount: 0,
+                hasMoreMessages: false
             };
             ConversationReducer(beforeState, {
                 type: ADD_MESSAGE,
@@ -212,7 +211,8 @@ describe('Conversation reducer', () => {
             const beforeState = INITIAL_STATE;
             const afterState = ConversationReducer(beforeState, {
                 type: ADD_MESSAGE,
-                message: WHISPER_MESSAGE
+                message: WHISPER_MESSAGE,
+                hasMoreMessages: false
             });
             afterState.messages.length.should.eq(1);
             afterState.messages[0].should.eql(WHISPER_MESSAGE);
@@ -312,7 +312,8 @@ describe('Conversation reducer', () => {
         const beforeState = INITIAL_STATE;
         const afterState = {
             messages: [],
-            unreadCount: 1
+            unreadCount: 1,
+            hasMoreMessages: false
         };
         ConversationReducer(beforeState, {
             type: INCREMENT_UNREAD_COUNT
@@ -322,7 +323,8 @@ describe('Conversation reducer', () => {
     it('should reset unread count on RESET_UNREAD_COUNT', () => {
         const beforeState = {
             messages: [],
-            unreadCount: 100
+            unreadCount: 100,
+            hasMoreMessages: false
         };
         const afterState = INITIAL_STATE;
         ConversationReducer(beforeState, {

--- a/test/specs/reducers/conversation-reducer.spec.js
+++ b/test/specs/reducers/conversation-reducer.spec.js
@@ -141,7 +141,8 @@ describe('Conversation reducer', () => {
             const afterState = {
                 messages: [MESSAGE_FROM_APP_USER],
                 unreadCount: 0,
-                hasMoreMessages: false
+                hasMoreMessages: false,
+                isFetchingMoreMessagesFromServer: false
             };
             ConversationReducer(beforeState, {
                 type: ADD_MESSAGE,
@@ -212,7 +213,8 @@ describe('Conversation reducer', () => {
             const afterState = ConversationReducer(beforeState, {
                 type: ADD_MESSAGE,
                 message: WHISPER_MESSAGE,
-                hasMoreMessages: false
+                hasMoreMessages: false,
+                isFetchingMoreMessagesFromServer: false
             });
             afterState.messages.length.should.eq(1);
             afterState.messages[0].should.eql(WHISPER_MESSAGE);
@@ -336,9 +338,17 @@ describe('Conversation reducer', () => {
         });
 
         it('should not add duplicates', () => {
-
+            const beforeState = {
+                messages: [MESSAGE_1]
+            };
+            const afterState = ConversationReducer(beforeState, {
+                type: ADD_MESSAGES,
+                messages: [MESSAGE_1],
+                append: true
+            });
+            afterState.messages.length.should.eq(1);
+            afterState.messages[0].should.eq(MESSAGE_1);
         });
-
     });
 
     it('should set to initial state on RESET_CONVERSATION', () => {
@@ -357,7 +367,8 @@ describe('Conversation reducer', () => {
         const afterState = {
             messages: [],
             unreadCount: 1,
-            hasMoreMessages: false
+            hasMoreMessages: false,
+            isFetchingMoreMessagesFromServer: false
         };
         ConversationReducer(beforeState, {
             type: INCREMENT_UNREAD_COUNT
@@ -368,7 +379,8 @@ describe('Conversation reducer', () => {
         const beforeState = {
             messages: [],
             unreadCount: 100,
-            hasMoreMessages: false
+            hasMoreMessages: false,
+            isFetchingMoreMessagesFromServer: false
         };
         const afterState = INITIAL_STATE;
         ConversationReducer(beforeState, {

--- a/test/specs/reducers/conversation-reducer.spec.js
+++ b/test/specs/reducers/conversation-reducer.spec.js
@@ -1,5 +1,5 @@
 import { ConversationReducer } from '../../../src/js/reducers/conversation-reducer';
-import { ADD_MESSAGE, REPLACE_MESSAGE, RESET_CONVERSATION, REMOVE_MESSAGE, SET_CONVERSATION, RESET_UNREAD_COUNT, INCREMENT_UNREAD_COUNT } from '../../../src/js/actions/conversation-actions';
+import { ADD_MESSAGE, REPLACE_MESSAGE, RESET_CONVERSATION, REMOVE_MESSAGE, SET_CONVERSATION, RESET_UNREAD_COUNT, INCREMENT_UNREAD_COUNT, ADD_MESSAGES, SET_MESSAGES } from '../../../src/js/actions/conversation-actions';
 
 const INITIAL_STATE = ConversationReducer(undefined, {});
 const MESSAGE_1 = {
@@ -295,6 +295,50 @@ describe('Conversation reducer', () => {
             });
             afterState.messages.length.should.eq(0);
         });
+    });
+
+    describe('SET_MESSAGES action', () => {
+        it('should set action messages to state', () => {
+            const beforeState = INITIAL_STATE;
+            const afterState = ConversationReducer(beforeState, {
+                type: SET_MESSAGES,
+                messages: MESSAGES
+            });
+            afterState.messages.should.eql(MESSAGES);
+        });
+
+        it('should not add duplicate messages', () => {
+            const beforeState = INITIAL_STATE;
+            const afterState = ConversationReducer(beforeState, {
+                type: SET_MESSAGES,
+                messages: [...MESSAGES, ...MESSAGES]
+            });
+            afterState.messages.should.eql(MESSAGES);
+        });
+    });
+
+    describe('ADD_MESSAGES action', () => {
+        [true, false].forEach((shouldAppend) => {
+            describe(`append option is set to ${shouldAppend}`, () => {
+                it(`should add messages to the ${shouldAppend ? 'end' : 'beginning'} of the state messages`, () => {
+                    const beforeState = {
+                        messages: [MESSAGE_1]
+                    };
+                    const afterState = ConversationReducer(beforeState, {
+                        type: ADD_MESSAGES,
+                        messages: [MESSAGE_2],
+                        append: shouldAppend
+                    });
+                    const messages = shouldAppend ? [...MESSAGE_1, ...MESSAGE_2] : [...MESSAGE_1, ...MESSAGE_2];
+                    afterState.messages.should.eql(messages);
+                });
+            });
+        });
+
+        it('should not add duplicates', () => {
+
+        });
+
     });
 
     it('should set to initial state on RESET_CONVERSATION', () => {

--- a/test/specs/reducers/integrations-reducer.spec.js
+++ b/test/specs/reducers/integrations-reducer.spec.js
@@ -11,13 +11,6 @@ describe('Integrations reducer', () => {
         appUserNumberValid: true
     };
 
-    const INITIAL_STATE = IntegrationsReducer(undefined, {});
-    const TWILIO_ATTRIBUTES = {
-        linkState: 'linked',
-        appUserNumber: '+15145555555',
-        appUserNumberValid: true
-    };
-
     it('should set the WeChat QR Code with the actions prop on SET_WECHAT_QR_CODE', () => {
         IntegrationsReducer(undefined, {
             type: SET_WECHAT_QR_CODE,
@@ -51,7 +44,7 @@ describe('Integrations reducer', () => {
             type: RESET_INTEGRATIONS
         }).some).to.not.exist;
     });
-    
+
     describe('SET_TWILIO_INTEGRATION_STATE action', () => {
         it('should update with new twilio attributes', () => {
             const beforeState = INITIAL_STATE;

--- a/test/specs/services/conversation-service.spec.js
+++ b/test/specs/services/conversation-service.spec.js
@@ -383,7 +383,7 @@ describe('Conversation service', () => {
         });
     });
 
-    describe('getConversation', () => {
+    describe('getMessages', () => {
         beforeEach(() => {
             mockedStore = mockAppStore(sandbox, {
                 user: {
@@ -393,13 +393,13 @@ describe('Conversation service', () => {
         });
 
         it('should call smooch-core conversation api and dispatch conversation', () => {
-            return conversationService.getConversation().then((response) => {
-                coreMock.conversations.get.should.have.been.calledWith('1');
+            return conversationService.getMessages().then((response) => {
+                coreMock.appUsers.getMessages.should.have.been.calledWith('1');
 
                 response.should.deep.eq({
                     conversation: {
-                        messages: []
-                    }
+                    },
+                    messages: []
                 });
 
                 conversationActions.setConversation.should.have.been.called;

--- a/test/specs/services/conversation-service.spec.js
+++ b/test/specs/services/conversation-service.spec.js
@@ -74,10 +74,10 @@ describe('Conversation service', () => {
 
     beforeEach(() => {
         coreMock = createMock(sandbox);
-        coreMock.conversations.get.resolves({
+        coreMock.appUsers.getMessages.resolves({
             conversation: {
-                messages: []
-            }
+            },
+            messages: []
         });
 
         sandbox.stub(coreService, 'core', () => {
@@ -528,9 +528,9 @@ describe('Conversation service', () => {
 
                     return conversationService.handleConversationUpdated().then(() => {
                         if (active) {
-                            coreMock.conversations.get.should.not.have.been.called;
+                            coreMock.appUsers.getMessages.should.not.have.been.called;
                         } else {
-                            coreMock.conversations.get.should.have.been.calledOnce;
+                            coreMock.appUsers.getMessages.should.have.been.calledOnce;
                         }
                     });
                 });

--- a/test/specs/services/integrations-service.spec.js
+++ b/test/specs/services/integrations-service.spec.js
@@ -35,10 +35,10 @@ describe('Integrations service', () => {
         });
         coreMock.appUsers.unlinkChannel.resolves();
         coreMock.appUsers.pingChannel.resolves();
-        coreMock.conversations.get.resolves({
+        coreMock.appUsers.getMessages.resolves({
             conversation: {
-                messages: []
-            }
+            },
+            messages: []
         });
 
         sandbox.stub(coreService, 'core', () => {
@@ -89,7 +89,7 @@ describe('Integrations service', () => {
                 type: 'twilio',
                 phoneNumber: '+0123456789'
             }).then(() => {
-                coreMock.conversations.get.should.have.been.calledOnce;
+                coreMock.appUsers.getMessages.should.have.been.calledOnce;
                 utilsFaye.subscribeConversation.should.have.been.calledOnce;
             });
         });

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -93,8 +93,8 @@ describe('Smooch', () => {
 
     describe('Login', () => {
         let loginStub;
-        let getConversationStub;
         let immediateUpdateStub;
+        let handleConversationUpdatedStub;
 
         beforeEach(() => {
             mockedStore = mockAppStore(sandbox, defaultState);
@@ -111,11 +111,11 @@ describe('Smooch', () => {
             immediateUpdateStub = sandbox.stub(userService, 'immediateUpdate');
             immediateUpdateStub.resolves({});
 
-            getConversationStub = sandbox.stub(conversationService, 'getConversation');
-            getConversationStub.resolves({});
-
             connectFayeStub = sandbox.stub(conversationService, 'connectFayeConversation');
             connectFayeStub.resolves({});
+
+            handleConversationUpdatedStub = sandbox.stub(conversationService, 'handleConversationUpdated');
+            handleConversationUpdatedStub.resolves({});
 
             disconnectFayeStub = sandbox.stub(conversationService, 'disconnectFaye');
 
@@ -124,6 +124,9 @@ describe('Smooch', () => {
 
             const getIntegrationStub = sandbox.stub(appUtils, 'getIntegration');
             getIntegrationStub.returns({});
+
+            const getMessagesStub = sandbox.stub(conversationService, 'getMessages');
+            getMessagesStub.resolves({});
 
         });
 
@@ -177,8 +180,8 @@ describe('Smooch', () => {
                     immediateUpdateStub.should.have.been.calledWith, {
                         email: 'some@email.com'
                     };
-                    getConversationStub.should.have.been.calledOnce;
-                    connectFayeStub.should.have.been.calledOnce;
+                    handleConversationUpdatedStub.should.have.been.calledOnce;
+                    connectFayeStub.should.not.have.been.called;
                 });
             });
         });
@@ -209,7 +212,7 @@ describe('Smooch', () => {
                     immediateUpdateStub.should.have.been.calledWith, {
                         email: 'some@email.com'
                     };
-                    getConversationStub.should.not.have.been.called;
+                    handleConversationUpdatedStub.should.not.have.been.called;
                     connectFayeStub.should.not.have.been.called;
                 });
             });
@@ -254,19 +257,20 @@ describe('Smooch', () => {
     });
 
     describe('Get conversation', () => {
+
+        let handleConversationUpdatedStub;
+
         beforeEach(() => {
             mockedStore = mockAppStore(sandbox, defaultState);
-            sandbox.stub(conversationService, 'handleConversationUpdated');
+            handleConversationUpdatedStub = sandbox.stub(conversationService, 'handleConversationUpdated');
+            handleConversationUpdatedStub.resolves({});
         });
 
         describe('conversation exists', () => {
-            beforeEach(() => {
-                conversationService.handleConversationUpdated.resolves({});
-            });
 
             it('should call handleConversationUpdated', () => {
                 return smooch.getConversation().then(() => {
-                    conversationService.handleConversationUpdated.should.have.been.calledOnce;
+                    handleConversationUpdatedStub.should.have.been.calledOnce;
                 });
             });
 
@@ -292,7 +296,7 @@ describe('Smooch', () => {
 
         describe('conversation does not exist', () => {
             beforeEach(() => {
-                conversationService.handleConversationUpdated.rejects();
+                handleConversationUpdatedStub.rejects();
             });
 
             it('should reject', (done) => {

--- a/test/specs/utils/faye.spec.js
+++ b/test/specs/utils/faye.spec.js
@@ -10,7 +10,7 @@ import * as conversationActions from '../../../src/js/actions/conversation-actio
 import * as conversationService from '../../../src/js/services/conversation-service';
 import * as appService from '../../../src/js/services/app-service';
 
-function getProps(props = {}){
+function getProps(props = {}) {
     const state = {
         user: {
             conversationStarted: true
@@ -43,7 +43,7 @@ describe('Faye utils', () => {
 
     beforeEach(() => {
         sandbox.stub(Client.prototype, 'addExtension');
-        sandbox.stub(conversationService, 'getConversation');
+        sandbox.stub(conversationService, 'getMessages');
         sandbox.stub(conversationService, 'disconnectFaye');
         sandbox.stub(conversationService, 'handleConversationUpdated');
         sandbox.stub(appService, 'showSettings');
@@ -71,10 +71,10 @@ describe('Faye utils', () => {
             });
         });
         describe('when conversation is started', () => {
-            it('should call getconversation when transport:up event is emitted', () => {
+            it('should call getMessages when transport:up event is emitted', () => {
                 const client = utilsFaye.getClient();
                 client.subscribe();
-                conversationService.getConversation.should.have.been.calledOnce;
+                conversationService.getMessages.should.have.been.calledOnce;
             });
         });
 
@@ -87,10 +87,10 @@ describe('Faye utils', () => {
                 }));
             });
 
-            it('should not call getconversation when transport:up event is emitted', () => {
+            it('should not call getMessages when transport:up event is emitted', () => {
                 const client = utilsFaye.getClient();
                 client.subscribe();
-                conversationService.getConversation.should.not.have.been.called;
+                conversationService.getMessages.should.not.have.been.called;
             });
         });
     });
@@ -114,7 +114,7 @@ describe('Faye utils', () => {
                             source: {
                                 id: 1
                             },
-                            role: appUser ? 'appUser' :  'appMaker'
+                            role: appUser ? 'appUser' : 'appMaker'
                         };
                         utilsFaye.handleConversationSubscription(message);
                         appUser ? conversationActions.resetUnreadCount.should.have.been.calledOnce : conversationActions.resetUnreadCount.should.not.have.been.called;
@@ -186,7 +186,7 @@ describe('Faye utils', () => {
                 it('should fetch conversation', () => {
                     currentAppUser.conversationStarted = true;
                     utilsFaye.updateUser(currentAppUser, nextAppUser);
-                    conversationService.getConversation.should.have.been.calledOnce;
+                    conversationService.getMessages.should.have.been.calledOnce;
                 });
             });
             describe('next appUser started conversation', () => {


### PR DESCRIPTION
Using the new API endpoint, only 100 messages are fetched at time. When scrolling up, older messages will be fetched.

![pagination_1](https://cloud.githubusercontent.com/assets/4314491/17753613/9e034b50-649e-11e6-86aa-1ffb2f53bdd5.gif)

![pagination_3](https://cloud.githubusercontent.com/assets/4314491/17753636/b1ff6b84-649e-11e6-8684-64036ca2a616.gif) ![pagination_2](https://cloud.githubusercontent.com/assets/4314491/17753635/b1fe8a98-649e-11e6-889b-431f1c5227e8.gif)

In order to get the render to work well, I had to make a few changes to the `Introduction` component. Instead of calculating its height on every `componentWillUpdate`, I only calculate it on `componentDidMount` and on a resize event. This fixes some of the weird animation glitches we had observed before.

A few things to note on the scroll behavior:
- An appUser sending a message will cause the conversation to scroll the bottom.
- If the appUser has scrolled the conversation up (towards older messages), and an appMaker sends a message, then the conversation will not scroll to the bottom. 
- If the appUser is at the bottom of the conversation (newer messages), and an appMaker sends a message, then the conversation will scroll to the bottom.
- Scrolling to the 'top' of the conversation will fetch older messages. 
- Older messages can also be fetched by clicking on the `Load more` link. This link shows up when you've scrolled up (but not all the way to the top!)
- When older messages get fetched, the messages stay in the same position they originally were (the first screenshot shows this well 😁 )

@mspensieri @dannytranlx @alavers @lemieux 