### PR TITLE
Resolve warning for 'flood-color' should be actually 'floodColor'

### DIFF
--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -20,7 +20,7 @@ export class DefaultButtonIcon extends Component {
                        <feOffset dx='0'
                                  dy='4'
                                  result='offsetblur' />
-                       <feFlood flood-color={ `#${brandColor}` } />
+                       <feFlood floodColor={ `#${brandColor}` } />
                        <feComponentTransfer>
                            <feFuncA type='linear'
                                     slope='0.4' />


### PR DESCRIPTION
Currently, if you use this component, it works but the console keeps throwing warnings. Let's keep a 0 warning policy 👍 