### PR TITLE
Prevent chat input from inheriting CSS from page

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -103,6 +103,7 @@
             background-color: white;
             border: 1px solid white;
             padding: 0px;
+            font: inherit;
         }
 
         .content-wrapper {


### PR DESCRIPTION
In some cases, the chat input would take on the CSS of the page it was on, causing the style to clash with the current Smooch style. To prevent this from happening, force the Smooch chat input to inherit from its parent element.

If you want to customize the chat input, you can edit the CSS: `#sk-holder #sk-container .input`

@jugarrit @dannytranlx @mspensieri 