### PR TITLE
Fix error notification padding

### DIFF
--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -11,10 +11,6 @@
         height: @conversation-height-mobile;
     }
 
-    &.notification-shown {
-        padding-top: @notification-height;
-    }
-
     .sk-intro-section {
         background-color: #F8F9FA;
         padding: 18px 18px 22px 18px;

--- a/src/stylesheets/notification.less
+++ b/src/stylesheets/notification.less
@@ -6,13 +6,7 @@
 
     .sk-notification {
         overflow: hidden;
-
-        height: @notification-height;
         width: 100%;
-
-        &.long-text {
-            height: @long-notification-height;
-        }
 
         border-top: 1px solid rgba(0, 0, 0, .1);
         background-color: white;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -81,4 +81,3 @@
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
 
 @notification-height: 56px;
-@long-notification-height: 75px;


### PR DESCRIPTION
I removed the changing top padding on the Introduction component and I removed the height on the Notification element (it's defined in the animation). 

This works for both one-line and two-line messages.

![error-notification-short-message](https://cloud.githubusercontent.com/assets/4314491/17909586/1cf6d34c-6953-11e6-9de1-142940b1f0f1.gif)
![error-notif-long-message](https://cloud.githubusercontent.com/assets/4314491/17909587/1cfbf106-6953-11e6-8c44-350c96d00fab.gif)

@dannytranlx @mspensieri @spasiu @lemieux 