### PR TITLE
Bump up react-messenger-plugin version to avoid deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-addons-css-transition-group": "15.1.0",
     "react-document-title": "2.0.1",
     "react-imageloader": "2.1.0",
-    "react-messenger-plugin": "1.0.0",
+    "react-messenger-plugin": "1.0.1",
     "react-onclickoutside": "5.3.1",
     "react-redux": "4.4.5",
     "react-spinkit": "1.1.4",


### PR DESCRIPTION
Fixes #370

Linked to this https://github.com/lemieux/react-messenger-plugin/pull/2

Basically, react-messenger-plugin was making an explicit call to a PropType validator and that's deprecated in the next major version.

@alavers @mspensieri @jugarrit 