### PR TITLE
Fix intro height computation

### DIFF
--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -31,6 +31,7 @@ export class IntroductionComponent extends Component {
     componentDidMount() {
         // Height of Introduction component will be computed on render and on resize only
         window.addEventListener('resize', this._debounceClientHeightCalculation);
+        this.calculateIntroHeight();
     }
 
     componentWillUnmount() {

--- a/src/js/components/introduction.jsx
+++ b/src/js/components/introduction.jsx
@@ -31,7 +31,7 @@ export class IntroductionComponent extends Component {
     componentDidMount() {
         // Height of Introduction component will be computed on render and on resize only
         window.addEventListener('resize', this._debounceClientHeightCalculation);
-        this.calculateIntroHeight();
+        setTimeout(this.calculateIntroHeight.bind(this));
     }
 
     componentWillUnmount() {
@@ -39,7 +39,7 @@ export class IntroductionComponent extends Component {
     }
 
     componentDidUpdate() {
-        this.calculateIntroHeight();
+        setTimeout(this.calculateIntroHeight.bind(this));
     }
 
     calculateIntroHeight() {

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -13,9 +13,9 @@
 
     .sk-intro-section {
         background-color: #F8F9FA;
-        padding: 18px 18px 22px 18px;
+        padding: @intro-padding @intro-padding @intro-padding-bottom @intro-padding;
         border-bottom: solid 1px #E6E6E6;
-        min-height: 90px; // app icon height + intro padding
+        min-height: @intro-icon-size + @intro-padding + @intro-padding-bottom; // app icon height + intro padding
 
         .app-name {
             color: #464646;
@@ -32,8 +32,8 @@
 
         .app-icon {
             float: left;
-            width: 50px;
-            height: 50px;
+            width: @intro-icon-size;
+            height: @intro-icon-size;
             border-radius: 50%;
         }
 

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -15,7 +15,7 @@
         background-color: #F8F9FA;
         padding: @intro-padding @intro-padding @intro-padding-bottom @intro-padding;
         border-bottom: solid 1px #E6E6E6;
-        min-height: @intro-icon-size + @intro-padding + @intro-padding-bottom; // app icon height + intro padding
+        min-height: @intro-icon-size + @intro-padding + @intro-padding-bottom;
 
         .app-name {
             color: #464646;

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -15,7 +15,7 @@
         background-color: #F8F9FA;
         padding: 18px 18px 22px 18px;
         border-bottom: solid 1px #E6E6E6;
-        min-height: 158px;
+        min-height: 90px; // app icon height + intro padding
 
         .app-name {
             color: #464646;

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -81,3 +81,7 @@
 @widget-close-top-lg: calc(~"100% - @{widget-height-lg}");
 
 @notification-height: 56px;
+
+@intro-padding: 18px;
+@intro-padding-bottom: 22px;
+@intro-icon-size: 50px;


### PR DESCRIPTION
Not sure why a min-height was introduced in https://github.com/smooch/smooch-js/pull/378/commits/c7f2a0ff3450e6434b88227252015ea4ae70b9cf, but it was forcing the intro to always be 158px. That caused problems when no channels are active since it leaves a big empty space.

This fix reduces the min-height to be the absolute min-height needed (to fit at least the app icon). The height will also be compute on mount as before. Again, not sure why this was changed.

@alavers @mspensieri @jugarrit @dannytranlx 