### PR TITLE
Enable scroll to bottom before adding temp message

### DIFF
--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -85,6 +85,7 @@ export function sendMessage(text) {
             deviceId: getDeviceId()
         };
 
+        store.dispatch(setShouldScrollToBottom(true));
         store.dispatch(addMessage(message));
 
         const {user} = store.getState();


### PR DESCRIPTION
The problem was that scroll to bottom wasn't enabled before adding the temporary message, so the conversation would only scroll after receiving the response from the server. This fixes it.

@alavers @mspensieri @dannytranlx @jugarrit 