### PR TITLE
Fix dropshadow on messenger button icon

### DIFF
--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -6,7 +6,7 @@ import { SK_DARK_CONTRAST } from '../constants/styles';
 
 export class DefaultButtonIcon extends Component {
     render() {
-        const {isBrandColorDark, brandColor} = this.props;
+        const {isBrandColorDark} = this.props;
 
         return <svg version='1.0'
                     x='0px'
@@ -20,7 +20,6 @@ export class DefaultButtonIcon extends Component {
                        <feOffset dx='0'
                                  dy='4'
                                  result='offsetblur' />
-                       <feFlood floodColor={ `#${brandColor}` } />
                        <feComponentTransfer>
                            <feFuncA type='linear'
                                     slope='0.4' />


### PR DESCRIPTION
It seems that #375 made the dropshadow disappears, but not really the PR's fault. Seems like the PR made `feFlood` be used correctly on the svg, but by working correctly it means no dropshadow. Before the PR, the attribute was just invalid and React didn't add it which made the `feFlood` tag having no effect. For some reason, the valid `flood-color` attribute is just making the shadow disappear.

This PR removes the `feFlood` and brings back the shadow.

![image](https://cloud.githubusercontent.com/assets/781844/18277854/ef776550-741d-11e6-97dc-815813cc86a5.png)

@alavers @dannytranlx @jugarrit @mspensieri 