### PR TITLE
Use own umd loader instead of webpack's

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
     var entry = options.assetsOnly ? {
         assets: './src/js/constants/assets'
     } : {
-        smooch: ['./src/js/utils/polyfills', './src/js/main']
+        smooch: ['./src/js/utils/polyfills', './src/js/umd']
     };
 
     const fileLimit = options.bundleAll ? 100000 : 1;
@@ -60,8 +60,7 @@ module.exports = function(options) {
         chunkFilename: (options.devServer ? '[id].js' : '[name].js') + (options.longTermCaching ? '?[chunkhash]' : ''),
         sourceMapFilename: '[file].map',
         library: options.assetsOnly ? undefined : 'Smooch',
-        libraryTarget: options.assetsOnly ? 'commonjs2' : 'umd',
-        umdNamedDefine: true,
+        libraryTarget: 'var',
         pathinfo: options.debug
     };
 

--- a/src/js/umd.js
+++ b/src/js/umd.js
@@ -1,0 +1,16 @@
+import { Smooch } from './smooch';
+
+(function(root, factory) {
+    /* global define:false */
+    if (typeof define === 'function' && define.amd) {
+        define([], function() {
+            return (root.Smooch = factory());
+        });
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.Smooch = factory();
+    }
+}(global, () => {
+    return new Smooch();
+}));


### PR DESCRIPTION
Webpack's umd loader is either using `module.exports`, using `define`, or publishing a browser global. The problem with this is that if a website is using require.js in other script, then `define` becomes a global and then prevent the widget from working as a global.

These modifications will allow the widget to be loaded as a CommonJS module or as an AMD module AND it will publish a global. I created a new entry file for the umd wrapper and kept the existing one as the entry point when the lib is used as an npm module. When using it like that it wouldn't expose a global. 

@alavers @mspensieri @jugarrit @Hebime 