### PR TITLE
Release 3.4.1

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
     var entry = options.assetsOnly ? {
         assets: './src/js/constants/assets'
     } : {
-        smooch: ['./src/js/utils/polyfills', './src/js/main']
+        smooch: ['./src/js/utils/polyfills', './src/js/umd']
     };
 
     const fileLimit = options.bundleAll ? 100000 : 1;
@@ -60,8 +60,7 @@ module.exports = function(options) {
         chunkFilename: (options.devServer ? '[id].js' : '[name].js') + (options.longTermCaching ? '?[chunkhash]' : ''),
         sourceMapFilename: '[file].map',
         library: options.assetsOnly ? undefined : 'Smooch',
-        libraryTarget: options.assetsOnly ? 'commonjs2' : 'umd',
-        umdNamedDefine: true,
+        libraryTarget: 'var',
         pathinfo: options.debug
     };
 

--- a/release_notes/v3.4.1.md
+++ b/release_notes/v3.4.1.md
@@ -1,0 +1,3 @@
+# What's new?
+- Drop shadow on the chat bubble icon disappeared in a previous release. We brought it back.
+- When require.js was present in the page, the library was not publishing the Smooch global variable. This is now fixed.

--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -6,7 +6,7 @@ import { SK_DARK_CONTRAST } from '../constants/styles';
 
 export class DefaultButtonIcon extends Component {
     render() {
-        const {isBrandColorDark, brandColor} = this.props;
+        const {isBrandColorDark} = this.props;
 
         return <svg version='1.0'
                     x='0px'
@@ -20,7 +20,6 @@ export class DefaultButtonIcon extends Component {
                        <feOffset dx='0'
                                  dy='4'
                                  result='offsetblur' />
-                       <feFlood floodColor={ `#${brandColor}` } />
                        <feComponentTransfer>
                            <feFuncA type='linear'
                                     slope='0.4' />

--- a/src/js/umd.js
+++ b/src/js/umd.js
@@ -1,0 +1,16 @@
+import { Smooch } from './smooch';
+
+(function(root, factory) {
+    /* global define:false */
+    if (typeof define === 'function' && define.amd) {
+        define([], function() {
+            return (root.Smooch = factory());
+        });
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.Smooch = factory();
+    }
+}(global, () => {
+    return new Smooch();
+}));


### PR DESCRIPTION
# What's new?
- Drop shadow on the chat bubble icon disappeared in a previous release. We brought it back.
- When require.js was present in the page, the library was not publishing the Smooch global variable. This is now fixed.
