### PR TITLE
Fix assets file for npm build

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -60,7 +60,7 @@ module.exports = function(options) {
         chunkFilename: (options.devServer ? '[id].js' : '[name].js') + (options.longTermCaching ? '?[chunkhash]' : ''),
         sourceMapFilename: '[file].map',
         library: options.assetsOnly ? undefined : 'Smooch',
-        libraryTarget: 'var',
+        libraryTarget: options.assetsOnly ? 'commonjs2' : 'var',
         pathinfo: options.debug
     };
 

--- a/release_notes/v3.4.2.md
+++ b/release_notes/v3.4.2.md
@@ -1,0 +1,2 @@
+# What's new?
+- The lib became unusable via npm with the last release. A change in the build configuration was fixed.


### PR DESCRIPTION
Last release broke the npm version of the library. `npm build:assets` output was a js file that didn't export anything because `libraryTarget` was set to `var`. This is fixed.

Will fix #397.

I'd like to release this ASAP.

@mspensieri @dannytranlx @jugarrit @Hebime 