### PR TITLE
Release 3.4.2

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -60,7 +60,7 @@ module.exports = function(options) {
         chunkFilename: (options.devServer ? '[id].js' : '[name].js') + (options.longTermCaching ? '?[chunkhash]' : ''),
         sourceMapFilename: '[file].map',
         library: options.assetsOnly ? undefined : 'Smooch',
-        libraryTarget: 'var',
+        libraryTarget: options.assetsOnly ? 'commonjs2' : 'var',
         pathinfo: options.debug
     };
 

--- a/release_notes/v3.4.2.md
+++ b/release_notes/v3.4.2.md
@@ -1,0 +1,2 @@
+# What's new?
+- The lib became unusable via npm with the last release. A change in the build configuration was fixed.


### PR DESCRIPTION
# What's new?
- The lib became unusable via npm with the last release. A change in the build configuration was fixed.
