### PR TITLE
Add instructions for peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install from npm
 ```
 npm install --save smooch
 
-// The library also have peer dependencies. If you don't already have them in your project, go ahead and install them too
+// The library also has peer dependencies. If you don't already have them in your project, go ahead and install them too
 
 npm install --save babel-polyfill@6.9 babel-runtime@6.9 react@15 react-dom@15
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Initialize the plugin using this code snippet
 Install from npm
 
 ```
-npm install smooch
+npm install --save smooch
+
+// The library also have peer dependencies. If you don't already have them in your project, go ahead and install them too
+
+npm install --save babel-polyfill@6.9 babel-runtime@6.9 react@15 react-dom@15
 ```
 
 Require and init


### PR DESCRIPTION
#403 made me realize the instructions were unclear about peer dependencies.

This adds a note about the need to install them if not already part of the project.

@alavers @mspensieri @dannytranlx @jugarrit 