### PR TITLE
Hide messenger when printing

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -158,3 +158,4 @@
 
 
 @import "mobile.less";
+@import "print.less";

--- a/src/stylesheets/print.less
+++ b/src/stylesheets/print.less
@@ -1,0 +1,9 @@
+@media print {
+    #sk-holder {
+        // do not target embedded since it's part of the UI
+        #sk-container,
+        #sk-messenger-button {
+            display: none;
+        }
+    }
+}


### PR DESCRIPTION
It was an quick and easy improvement for #401.

It will hide it when printing a non-embedded version of it.

@dannytranlx @alavers @mspensieri 