### PR TITLE
Expose Smooch-Core instance and userId

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Smooch.updateUser({
 Returns the userId of the current user.
 
 ```javascript
-Smooch.getUser()
+Smooch.getUserId()
 ```
 
 #### getConversation()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Smooch Javascript SDK](https://smooch.io)
+# [Smooch Web Messenger](https://smooch.io)
 
   [![Circle CI](https://circleci.com/gh/smooch/smooch-js.svg?style=svg)](https://circleci.com/gh/smooch/smooch-js)
   [![npm version](https://badge.fury.io/js/smooch.svg)](http://badge.fury.io/js/smooch)
@@ -6,7 +6,7 @@
 
 Smooch is the best way to have personal, rich conversations with people on your website or customers on any device. Our features, integrations and developer-friendly APIs empower companies to connect with their customers in a whole new way.
 
-The Smooch Javascript SDK will add [live web messaging](https://smooch.io/live-web-chat/) to your website or web app. Customers will be able to talk to you from your website, while you manage conversations using your favorite business systems.
+The Smooch Web Messenger will add [live web messaging](https://smooch.io/live-web-chat/) to your website or web app. Customers will be able to talk to you from your website, while you manage conversations using your favorite business systems.
 
 - Let your customers talk to you the way they want by seamlessly [moving web chat conversations](https://smooch.io/cross-channel-messaging/) to any messaging app.
 - Sync conversations across every device and channel your customers use.
@@ -241,6 +241,13 @@ Smooch.updateUser({
 });
 ```
 
+#### getUserId()
+Returns the userId of the current user.
+
+```javascript
+Smooch.getUser()
+```
+
 #### getConversation()
 Returns promise that resolves to conversation object, or rejects if none exists
 
@@ -254,6 +261,9 @@ Tracks an event for the current user.
 ```javascript
 Smooch.track('item-in-cart');
 ```
+
+#### getCore()
+Returns an instance of [smooch-core](https://github.com/smooch/smooch-core-js) to allow access to APIs the Web Messenger doesn't expose. For more information on how to use Smooch-Core, please visit the [documentation](http://docs.smooch.io/rest/?javascript).
 
 ### Events
 If you want to make sure your events are triggered, try to bind them before calling `Smooch.init`.

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -18,7 +18,7 @@ import { login } from './services/auth-service';
 import { getAccount } from './services/stripe-service';
 import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, updateNowViewing, immediateUpdate as immediateUpdateUser, getUserId } from './services/user-service';
 import { sendMessage, disconnectFaye, handleConversationUpdated } from './services/conversation-service';
-import { core } from './services/core-service';
+import { core } from './services/core';
 
 import { observable, observeStore } from './utils/events';
 import { waitForPage, monitorUrlChanges, stopMonitoringUrlChanges, monitorBrowserState, stopMonitoringBrowserState } from './utils/dom';

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -16,8 +16,9 @@ import { reset } from './actions/common-actions';
 import { openWidget, closeWidget, hideSettings, hideChannelPage } from './services/app-service';
 import { login } from './services/auth-service';
 import { getAccount } from './services/stripe-service';
-import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, updateNowViewing, immediateUpdate as immediateUpdateUser } from './services/user-service';
+import { EDITABLE_PROPERTIES, trackEvent, update as updateUser, updateNowViewing, immediateUpdate as immediateUpdateUser, getUserId } from './services/user-service';
 import { sendMessage, disconnectFaye, handleConversationUpdated } from './services/conversation-service';
+import { core } from './services/core-service';
 
 import { observable, observeStore } from './utils/events';
 import { waitForPage, monitorUrlChanges, stopMonitoringUrlChanges, monitorBrowserState, stopMonitoringBrowserState } from './utils/dom';
@@ -287,6 +288,14 @@ export class Smooch {
             }));
             return store.getState().conversation;
         });
+    }
+
+    getUserId() {
+        return getUserId();
+    }
+
+    getCore() {
+        return core();
     }
 
     destroy() {

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -4,7 +4,7 @@ import { mockAppStore } from '../utils/redux';
 
 import * as authService from '../../src/js/services/auth-service';
 import * as conversationService from '../../src/js/services/conversation-service';
-import * as coreService from '../../src/js/services/core-service';
+import * as coreService from '../../src/js/services/core';
 import * as userService from '../../src/js/services/user-service';
 import * as appUtils from '../../src/js/utils/app';
 
@@ -481,8 +481,8 @@ describe('Smooch', () => {
         beforeEach(() => {
             mockedStore = mockAppStore(sandbox, defaultState);
 
-            getUserIdStub = sandbox.stub(conversationService, 'getUserId');
-            sendMessageStub.returns('1234');
+            getUserIdStub = sandbox.stub(userService, 'getUserId');
+            getUserIdStub.returns('1234');
         });
 
         it('should call the conversation service', () => {
@@ -492,7 +492,7 @@ describe('Smooch', () => {
 
     describe('Get Core', () => {
         beforeEach(() => {
-            coreStub = sandbox.stub(conversationService, 'core');
+            coreStub = sandbox.stub(coreService, 'core');
         });
 
         it('should call the core service', () => {

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -2,11 +2,13 @@ import sinon from 'sinon';
 
 import { mockAppStore } from '../utils/redux';
 
-import { Smooch } from '../../src/js/smooch';
 import * as authService from '../../src/js/services/auth-service';
 import * as conversationService from '../../src/js/services/conversation-service';
+import * as coreService from '../../src/js/services/core-service';
 import * as userService from '../../src/js/services/user-service';
 import * as appUtils from '../../src/js/utils/app';
+
+import { Smooch } from '../../src/js/smooch';
 
 const defaultState = {
     user: {
@@ -42,6 +44,8 @@ describe('Smooch', () => {
     let disconnectFayeStub;
     let updateUserStub;
     let trackEventStub;
+    let getUserIdStub;
+    let coreStub;
     let mockedStore;
 
     after(() => {
@@ -470,6 +474,30 @@ describe('Smooch', () => {
                 smooch.close();
                 mockedStore.dispatch.should.not.have.been.called;
             });
+        });
+    });
+
+    describe('Get User Id', () => {
+        beforeEach(() => {
+            mockedStore = mockAppStore(sandbox, defaultState);
+
+            getUserIdStub = sandbox.stub(conversationService, 'getUserId');
+            sendMessageStub.returns('1234');
+        });
+
+        it('should call the conversation service', () => {
+            return smooch.getUserId().should.eq('1234');
+        });
+    });
+
+    describe('Get Core', () => {
+        beforeEach(() => {
+            coreStub = sandbox.stub(conversationService, 'core');
+        });
+
+        it('should call the core service', () => {
+            smooch.getCore();
+            coreStub.should.have.been.calledOnce;
         });
     });
 });


### PR DESCRIPTION
`getUserId` was a missing part of the messenger interface and was needed in order to use `getCore` properly.

I also exposed `getCore` so people could make API calls directly without having the re-expose every single endpoint throught the messenger interface.

@dannytranlx @jugarrit  
