### PR TITLE
Preprend window.location to filter url

### DIFF
--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -32,7 +32,7 @@ export class DefaultButtonIcon extends Component {
                        </feMerge>
                    </filter>
                    <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
-                         filter='url(#dropShadow)'
+                         filter={`url(${window.location}#dropShadow)`}
                          d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
                </svg>;
     }


### PR DESCRIPTION
This fixes #390 and #422. The problem was that `<base href="/" />` was used in the page and messed with how the filter is used. This will prepend the current url in the `url` attribute and will make it work.

@dannytranlx @alavers @jugarrit 