### PR TITLE
More lenient Babel versions in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,8 +144,8 @@
     "webpack-dev-server": "1.14.0"
   },
   "peerDependencies": {
-    "babel-polyfill": "6.9.x",
-    "babel-runtime": "6.9.x",
+    "babel-polyfill": "6.x.x",
+    "babel-runtime": "6.x.x",
     "react": "15.x.x",
     "react-dom": "15.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -144,8 +144,8 @@
     "webpack-dev-server": "1.14.0"
   },
   "peerDependencies": {
-    "babel-polyfill": "6.x.x",
-    "babel-runtime": "6.x.x",
+    "babel-polyfill": ">=6.9.0 <7.0",
+    "babel-runtime": ">=6.9.0 <7.0",
     "react": "15.x.x",
     "react-dom": "15.x.x"
   },


### PR DESCRIPTION
As babel is concerned only with standards-based transpilation, I think it's safe to assume that any version `6.x.x` of the babel packages will work fine. This change improves DX as it allows us to use the latest version of these packages with whatever bugfixes they include rather than being tied to now-outdated versions of these packages.