### PR TITLE
Check for document.hasFocus before using it

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -82,7 +82,7 @@ function onWindowBlur() {
 }
 
 export function monitorBrowserState() {
-    store.dispatch(hasFocus(document.hasFocus()));
+    store.dispatch(hasFocus(document.hasFocus ? document.hasFocus() : true));
     window.addEventListener('focus', onWindowFocus);
     window.addEventListener('blur', onWindowBlur);
 }


### PR DESCRIPTION
As reported in #425 , `document.hasFocus` might not exist. This small changes will make sure it doesn't crash if it's not present.


Fixes #425.

@jugarrit @dannytranlx @alavers 