### PR TITLE
Fix fallback logic for localStorage

### DIFF
--- a/src/js/utils/storage.js
+++ b/src/js/utils/storage.js
@@ -2,7 +2,14 @@ const memoryStorage = {};
 
 function setItem(key, value) {
     try {
-        localStorage.setItem(key, value);
+        if (localStorage) {
+            // Safari with privacy options will have localStorage
+            // but won't let us write to it.
+            localStorage.setItem(key, value);
+        } else {
+            // Android WebView might not have localStorage at all.
+            memoryStorage[key] = value;
+        }
     }
     catch (err) {
         console.warn('Smooch local storage warn: localStorage not available; falling back on memory storage'); //eslint-disable-line no-console
@@ -11,14 +18,20 @@ function setItem(key, value) {
 }
 
 function getItem(key) {
-    const value = localStorage.getItem(key) || memoryStorage[key];
+    let value;
+
+    if (localStorage) {
+        value = localStorage.getItem(key) || memoryStorage[key];
+    } else {
+        value = memoryStorage[key];
+    }
 
     // per localStorage spec, it returns null when not found
     return value || null;
 }
 
 function removeItem(key) {
-    localStorage.removeItem(key);
+    localStorage && localStorage.removeItem(key);
     delete memoryStorage[key];
 }
 


### PR DESCRIPTION
Some browsers and webviews might not allow access to localStorage.

This fixes the fallback logic to in-memory storage when localStorage doesn't exist.

Fixes #426 .

@hebime @jugarrit @dannytranlx  