### PR TITLE
Add support for quick replies

### DIFF
--- a/src/js/components/action.jsx
+++ b/src/js/components/action.jsx
@@ -165,7 +165,7 @@ export class ActionComponent extends Component {
                            { buttonText }
                        </button>
                    </div>;
-        } else {
+        } else if (type === 'link') {
             const isJavascript = uri.startsWith('javascript:');
 
             return <div className='sk-action'>
@@ -176,6 +176,8 @@ export class ActionComponent extends Component {
                            { text }
                        </a>
                    </div>;
+        } else {
+            return null;
         }
     }
 }

--- a/src/js/components/action.jsx
+++ b/src/js/components/action.jsx
@@ -165,7 +165,7 @@ export class ActionComponent extends Component {
                            { buttonText }
                        </button>
                    </div>;
-        } else if (type === 'link') {
+        } else if (type === 'link' || type === 'buy' && !stripeIntegration) {
             const isJavascript = uri.startsWith('javascript:');
 
             return <div className='sk-action'>

--- a/src/js/components/action.jsx
+++ b/src/js/components/action.jsx
@@ -17,7 +17,7 @@ export class ActionComponent extends Component {
         text: PropTypes.string.isRequired,
         type: PropTypes.string,
         buttonColor: PropTypes.string,
-        amount: PropTypes.string,
+        amount: PropTypes.number,
         currency: PropTypes.string,
         uri: PropTypes.string,
         state: PropTypes.string,

--- a/src/js/components/action.jsx
+++ b/src/js/components/action.jsx
@@ -165,7 +165,7 @@ export class ActionComponent extends Component {
                            { buttonText }
                        </button>
                    </div>;
-        } else if (type === 'link' || type === 'buy' && !stripeIntegration) {
+        } else if (type === 'link' || (type === 'buy' && !stripeIntegration)) {
             const isJavascript = uri.startsWith('javascript:');
 
             return <div className='sk-action'>

--- a/src/js/components/chat-input.jsx
+++ b/src/js/components/chat-input.jsx
@@ -15,6 +15,13 @@ function checkAndResetUnreadCount() {
 
 export class ChatInputComponent extends Component {
 
+    static propTypes = {
+        accentColor: PropTypes.string,
+        imageUploadEnabled: PropTypes.bool.isRequired,
+        inputPlaceholderText: PropTypes.string.isRequired,
+        sendButtonText: PropTypes.string.isRequired
+    };
+
     constructor(...args) {
         super(...args);
 
@@ -54,7 +61,7 @@ export class ChatInputComponent extends Component {
     }
 
     render() {
-        const {linkColor, imageUploadEnabled, inputPlaceholderText, sendButtonText} = this.props;
+        const {accentColor, imageUploadEnabled, inputPlaceholderText, sendButtonText} = this.props;
 
         let sendButton;
 
@@ -64,8 +71,8 @@ export class ChatInputComponent extends Component {
         if (this.state.text.trim()) {
             buttonClassNames.push('active');
 
-            if (linkColor) {
-                buttonStyle.color = `#${linkColor}`;
+            if (accentColor) {
+                buttonStyle.color = `#${accentColor}`;
             }
         }
 
@@ -87,7 +94,7 @@ export class ChatInputComponent extends Component {
 
         const imageUploadButton = imageUploadEnabled ?
             <ImageUpload ref='imageUpload'
-                         color={ linkColor } /> : null;
+                         color={ accentColor } /> : null;
 
         const inputContainerClasses = ['input-container'];
 
@@ -117,7 +124,7 @@ export class ChatInputComponent extends Component {
 export const ChatInput = connect(({appState, app, ui}) => {
     return {
         imageUploadEnabled: appState.imageUploadEnabled,
-        linkColor: app.settings.web.linkColor,
+        accentColor: app.settings.web.accentColor,
         sendButtonText: ui.text.sendButtonText,
         inputPlaceholderText: ui.text.inputPlaceholder
     };

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -7,6 +7,7 @@ import { MessageComponent } from './message';
 import { ConnectNotification } from './connect-notification';
 import { logo, logo2x } from '../constants/assets';
 import { Introduction } from './introduction';
+import { QuickReplies } from './quick-replies';
 
 import { setShouldScrollToBottom, setFetchingMoreMessages } from '../actions/app-state-actions';
 import { fetchMoreMessages } from '../services/conversation-service';
@@ -207,6 +208,23 @@ export class ConversationComponent extends Component {
                                      onLoad={ this.scrollToBottom }
                                      {...message} />;
         });
+
+        if (messages.length > 0) {
+            const lastMessage = messages[messages.length - 1];
+            const replies = lastMessage.actions ? lastMessage.actions.filter((a) => a.type === 'reply') : [];
+
+            if (replies.length > 0) {
+                const choices = replies.map(({text, payload, iconUrl}) => {
+                    return {
+                        text,
+                        payload,
+                        iconUrl
+                    };
+                });
+                messageItems.push(<QuickReplies choices={ choices }
+                                                key='quick-replies' />);
+            }
+        }
 
         if (connectNotificationTimestamp) {
             const notificationIndex = messages.findIndex((message) => message.received > connectNotificationTimestamp);

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -23,7 +23,8 @@ export class ConversationComponent extends Component {
         connectNotificationTimestamp: PropTypes.number,
         introHeight: PropTypes.number.isRequired,
         messages: PropTypes.array.isRequired,
-        errorNotificationMessage: PropTypes.string
+        errorNotificationMessage: PropTypes.string,
+        quickReplies: PropTypes.array.isRequired
     };
 
     scrollTimeouts = [];
@@ -181,7 +182,7 @@ export class ConversationComponent extends Component {
     }
 
     render() {
-        const {connectNotificationTimestamp, introHeight, messages, errorNotificationMessage, isFetchingMoreMessages, hasMoreMessages, text, settings} = this.props;
+        const {connectNotificationTimestamp, introHeight, messages, quickReplies, errorNotificationMessage, isFetchingMoreMessages, hasMoreMessages, text, settings} = this.props;
         const {fetchingHistory, fetchHistory} = text;
         const {accentColor, linkColor} = settings;
 
@@ -209,21 +210,16 @@ export class ConversationComponent extends Component {
                                      {...message} />;
         });
 
-        if (messages.length > 0) {
-            const lastMessage = messages[messages.length - 1];
-            const replies = lastMessage.actions ? lastMessage.actions.filter((a) => a.type === 'reply') : [];
-
-            if (replies.length > 0) {
-                const choices = replies.map(({text, payload, iconUrl}) => {
-                    return {
-                        text,
-                        payload,
-                        iconUrl
-                    };
-                });
-                messageItems.push(<QuickReplies choices={ choices }
-                                                key='quick-replies' />);
-            }
+        if (quickReplies.length > 0) {
+            const choices = quickReplies.map(({text, payload, iconUrl}) => {
+                return {
+                    text,
+                    payload,
+                    iconUrl
+                };
+            });
+            messageItems.push(<QuickReplies choices={ choices }
+                                            key='quick-replies' />);
         }
 
         if (connectNotificationTimestamp) {
@@ -301,6 +297,7 @@ export class ConversationComponent extends Component {
 export const Conversation = connect(({appState, conversation, ui: {text}, app}) => {
     return {
         messages: conversation.messages,
+        quickReplies: conversation.quickReplies,
         embedded: appState.embedded,
         shouldScrollToBottom: appState.shouldScrollToBottom,
         isFetchingMoreMessages: appState.isFetchingMoreMessages,

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -138,19 +138,20 @@ export class ConversationComponent extends Component {
     };
 
     componentWillUpdate(nextProps) {
-        const {messages: currentMessages, isFetchingMoreMessages} = this.props;
-        const {messages: newMessages} = nextProps;
+        const {messages: currentMessages, quickReplies: currentQuickReplies, isFetchingMoreMessages} = this.props;
+        const {messages: newMessages, quickReplies: newQuickReplies} = nextProps;
 
-        if (!this._lastMessageNode) {
+        if (!this._lastNode) {
             this._forceScrollToBottom = true;
             return;
         }
 
         // Check for new appMaker (and whisper) messages
         const isAppMakerMessage = newMessages.length - currentMessages.length === 1 ? newMessages.slice(-1)[0].role !== 'appUser' : false;
-        if (isAppMakerMessage && !isFetchingMoreMessages) {
+        const quickRepliesChanged = currentQuickReplies.length !== newQuickReplies.length || currentQuickReplies.some((r, i) => r !== newQuickReplies[i]);
+        if ((isAppMakerMessage || quickRepliesChanged) && !isFetchingMoreMessages) {
             const container = findDOMNode(this);
-            const appMakerMessageBottom = this._lastMessageNode.getBoundingClientRect().bottom;
+            const appMakerMessageBottom = this._lastNode.getBoundingClientRect().bottom;
             const containerBottom = container.getBoundingClientRect().bottom;
 
             // If appMaker message is 'in view', we should scroll to bottom.
@@ -197,7 +198,7 @@ export class ConversationComponent extends Component {
                 }
 
                 if (index === messages.length - 1) {
-                    this._lastMessageNode = findDOMNode(c);
+                    this._lastNode = findDOMNode(c);
                     this._lastMessageId = message._id;
                 }
             };
@@ -218,7 +219,11 @@ export class ConversationComponent extends Component {
                     iconUrl
                 };
             });
-            messageItems.push(<QuickReplies choices={ choices }
+            const refCallback = (c) => {
+                this._lastNode = findDOMNode(c);
+            };
+            messageItems.push(<QuickReplies ref={ refCallback }
+                                            choices={ choices }
                                             key='quick-replies' />);
         }
 

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -12,7 +12,7 @@ export class MessageComponent extends Component {
         actions: PropTypes.array,
         role: PropTypes.string.isRequired,
         mediaUrl: PropTypes.string,
-        text: PropTypes.string.isRequired,
+        text: PropTypes.string,
         accentColor: PropTypes.string,
         linkColor: PropTypes.string,
         firstInGroup: PropTypes.bool,
@@ -20,9 +20,7 @@ export class MessageComponent extends Component {
     };
 
     static defaultProps = {
-        actions: [],
-        firstInGroup: true,
-        lastInGroup: true
+        actions: []
     };
 
     componentDidMount() {
@@ -45,27 +43,31 @@ export class MessageComponent extends Component {
     }
 
     render() {
-        const {name, actions, role, mediaUrl, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor} = this.props;
-        const actionList = actions
-            .filter((a) => a.type !== 'reply')
-            .map((action) => {
-                return <Action key={ action._id }
-                               buttonColor={ linkColor }
-                               {...action} />;
-            });
+        const {name, role, mediaUrl, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor} = this.props;
+        const actions = this.props.actions.filter((a) => a.type !== 'reply');
+
+        const actionList = actions.map((action) => {
+            return <Action key={ action._id }
+                           buttonColor={ linkColor }
+                           {...action} />;
+        });
 
         const isAppUser = role === 'appUser';
 
         const avatarClass = mediaUrl ? ['sk-msg-avatar', 'sk-msg-avatar-img'] : ['sk-msg-avatar'];
-        const avatar = isAppUser ? null : (
+
+        const avatar = isAppUser ?
+            null :
             <img className={ avatarClass.join(' ') }
-                 src={ avatarUrl } />
-            );
+                 src={ avatarUrl } />;
+
         const avatarPlaceHolder = isAppUser ? null : (<div className='sk-msg-avatar-placeholder' />);
 
         const message = mediaUrl ?
-            <ImageMessage {...this.props} /> :
-            <TextMessage {...this.props} />;
+            <ImageMessage {...this.props}
+                          actions={ actions } /> :
+            <TextMessage {...this.props}
+                         actions={ actions } />;
 
         const containerClass = [mediaUrl ? 'sk-msg-image' : 'sk-msg'];
 

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -31,55 +31,58 @@ export class MessageComponent extends Component {
     }
 
     render() {
-        const actions = this.props.actions.map((action) => {
-            return <Action key={ action._id }
-                                    buttonColor={ this.props.linkColor }
-                                    {...action} />;
-        });
+        const {name, actions, role, mediaUrl, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor} = this.props;
+        const actionList = actions
+            .filter((a) => a.type !== 'reply')
+            .map((action) => {
+                return <Action key={ action._id }
+                               buttonColor={ linkColor }
+                               {...action} />;
+            });
 
-        const isAppUser = this.props.role === 'appUser';
+        const isAppUser = role === 'appUser';
 
-        const avatarClass = this.props.mediaUrl ? ['sk-msg-avatar', 'sk-msg-avatar-img'] : ['sk-msg-avatar'];
+        const avatarClass = mediaUrl ? ['sk-msg-avatar', 'sk-msg-avatar-img'] : ['sk-msg-avatar'];
         const avatar = isAppUser ? null : (
             <img className={ avatarClass.join(' ') }
-                 src={ this.props.avatarUrl } />
+                 src={ avatarUrl } />
             );
         const avatarPlaceHolder = isAppUser ? null : (<div className='sk-msg-avatar-placeholder' />);
 
-        const message = this.props.mediaUrl ?
+        const message = mediaUrl ?
             <ImageMessage {...this.props} /> :
             <TextMessage {...this.props} />;
 
-        const containerClass = [this.props.mediaUrl ? 'sk-msg-image' : 'sk-msg'];
+        const containerClass = [mediaUrl ? 'sk-msg-image' : 'sk-msg'];
 
-        const hasContent = (this.props.text && this.props.text.trim()) || (this.props.mediaUrl && this.props.mediaUrl.trim());
+        const hasContent = (text && text.trim()) || (mediaUrl && mediaUrl.trim());
 
-        if (hasContent && this.props.actions.length > 0) {
+        if (hasContent && actions.length > 0) {
             containerClass.push('has-actions');
         }
 
         const style = {};
 
-        if (!this.props.mediaUrl) {
-            if (isAppUser && this.props.accentColor) {
-                style.backgroundColor = style.borderLeftColor = `#${this.props.accentColor}`;
+        if (!mediaUrl) {
+            if (isAppUser && accentColor) {
+                style.backgroundColor = style.borderLeftColor = `#${accentColor}`;
             }
         }
-        if (this.props.firstInGroup && !this.props.lastInGroup) {
+        if (firstInGroup && !lastInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-first');
             } else {
                 containerClass.push('sk-msg-appmaker-first');
             }
         }
-        if (this.props.lastInGroup && !this.props.firstInGroup) {
+        if (lastInGroup && !firstInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-last');
             } else {
                 containerClass.push('sk-msg-appmaker-last');
             }
         }
-        if (!this.props.firstInGroup && !this.props.lastInGroup) {
+        if (!firstInGroup && !lastInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-middle');
             } else {
@@ -88,18 +91,18 @@ export class MessageComponent extends Component {
         }
 
         const fromName = <div className='sk-from'>
-                             { isAppUser ? '' : this.props.name }
+                             { isAppUser ? '' : name }
                          </div>;
 
         return <div className={ 'sk-row ' + (isAppUser ? 'sk-right-row' : 'sk-left-row') }>
-                   { !isAppUser && this.props.firstInGroup ? fromName : '' }
-                   { this.props.lastInGroup ? avatar : avatarPlaceHolder }
+                   { !isAppUser && firstInGroup ? fromName : '' }
+                   { lastInGroup ? avatar : avatarPlaceHolder }
                    <div className='sk-msg-wrapper'>
                        <div className={ containerClass.join(' ') }
                             style={ style }
                             ref='messageContent'>
                            { message }
-                           { actions }
+                           { actionList }
                        </div>
                    </div>
                    <div className='sk-clear'></div>

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 import { TextMessage } from './text-message';
 import { ImageMessage } from './image-message';
@@ -7,8 +7,22 @@ import { findDOMNode } from 'react-dom';
 import { getElementProperties } from '../utils/dom';
 
 export class MessageComponent extends Component {
+    static propTypes = {
+        name: PropTypes.string,
+        actions: PropTypes.array,
+        role: PropTypes.string.isRequired,
+        mediaUrl: PropTypes.string,
+        text: PropTypes.string.isRequired,
+        accentColor: PropTypes.string,
+        linkColor: PropTypes.string,
+        firstInGroup: PropTypes.bool,
+        lastInGroup: PropTypes.bool
+    };
+
     static defaultProps = {
-        actions: []
+        actions: [],
+        firstInGroup: true,
+        lastInGroup: true
     };
 
     componentDidMount() {

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -45,6 +45,7 @@ export class MessageComponent extends Component {
     render() {
         const {name, role, mediaUrl, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor} = this.props;
         const actions = this.props.actions.filter((a) => a.type !== 'reply');
+        const hasQuickReplies = this.props.actions.length !== actions.length;
 
         const actionList = actions.map((action) => {
             return <Action key={ action._id }
@@ -84,6 +85,11 @@ export class MessageComponent extends Component {
                 style.backgroundColor = style.borderLeftColor = `#${accentColor}`;
             }
         }
+
+        if (hasQuickReplies) {
+            containerClass.push('sk-msg-has-quick-replies');
+        }
+
         if (firstInGroup && !lastInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-first');
@@ -91,6 +97,7 @@ export class MessageComponent extends Component {
                 containerClass.push('sk-msg-appmaker-first');
             }
         }
+
         if (lastInGroup && !firstInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-last');
@@ -98,6 +105,7 @@ export class MessageComponent extends Component {
                 containerClass.push('sk-msg-appmaker-last');
             }
         }
+
         if (!firstInGroup && !lastInGroup) {
             if (isAppUser) {
                 containerClass.push('sk-msg-appuser-middle');

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+import { MessageComponent } from './message';
 import { sendMessage } from '../services/conversation-service';
 import { getRGB, rgbToHsl } from '../utils/colors';
 
@@ -10,57 +11,74 @@ export class QuickRepliesComponent extends Component {
         choices: PropTypes.array.isRequired
     };
 
-    onReplyClick = ({text, payload}) => {
+    state = {
+        isSendingMessage: false
+    };
+
+    onReplyClick = ({text, payload, index}) => {
         Promise
             .resolve()
             .then(() => {
-                // animate the message
-            })
-            .then(() => sendMessage(text, {
-                payload
-            }));
+                this.setState({
+                    isSendingMessage: true,
+                    sendingChoiceIndex: index
+                })
+            });
+    // .then(() => sendMessage(text, {
+    //     payload
+    // }));
     };
+
 
 
     render() {
         const {choices, buttonColor} = this.props;
+        const {isSendingMessage, sendingChoiceIndex} = this.state;
+        if (isSendingMessage) {
+            const choice = choices[sendingChoiceIndex];
+            return <MessageComponent text={ choice.text }
+                            role='appUser'
+                            firstInGroup={ true }
+                            lastInGroup={ true } />;
+        } else {
+            const buttonStyle = {};
 
-        const buttonStyle = {};
+            if (buttonColor) {
+                const rgb = getRGB(`#${buttonColor}`);
+                const {h} = rgbToHsl(...rgb);
+                buttonStyle.backgroundColor = `hsl(${h}, 100%, 95%)`;
+                buttonStyle.borderColor = `#${buttonColor}`;
+                buttonStyle.color = `#${buttonColor}`;
+            }
 
-        if (buttonColor) {
-            const rgb = getRGB(`#${buttonColor}`);
-            const {h} = rgbToHsl(...rgb);
-            buttonStyle.backgroundColor = `hsl(${h}, 100%, 95%)`;
-            buttonStyle.borderColor = `#${buttonColor}`;
-            buttonStyle.color = `#${buttonColor}`;
+            const items = choices.map(({text, payload, iconUrl} , index) => {
+                const onClick = (e) => {
+                    e.preventDefault();
+                    this.onReplyClick({
+                        text,
+                        payload,
+                        index
+                    });
+                };
+
+                const icon = iconUrl ?
+                    <img className='sk-quick-reply-icon'
+                         src={ iconUrl } /> :
+                    null;
+
+                return <button className='btn btn-sk-quick-reply'
+                               style={ buttonStyle }
+                               onClick={ onClick }
+                               key={ index }>
+                           { icon }
+                           { text }
+                       </button>;
+            });
+
+            return <div className='sk-quick-replies-container'>
+                       { items }
+                   </div>;
         }
-
-        const items = choices.map(({text, payload, iconUrl} , index) => {
-            const onClick = (e) => {
-                e.preventDefault();
-                this.onReplyClick({
-                    text,
-                    payload
-                });
-            };
-
-            const icon = iconUrl ?
-                <img className='sk-quick-reply-icon'
-                     src={ iconUrl } /> :
-                null;
-
-            return <button className='btn btn-sk-quick-reply'
-                           style={ buttonStyle }
-                           onClick={ onClick }
-                           key={ index }>
-                       { icon }
-                       { text }
-                   </button>;
-        });
-
-        return <div className='sk-quick-replies-container'>
-                   { items }
-               </div>;
     }
 }
 

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -1,0 +1,71 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { sendMessage } from '../services/conversation-service';
+import { getRGB, rgbToHsl } from '../utils/colors';
+
+export class QuickRepliesComponent extends Component {
+    static propTypes = {
+        buttonColor: PropTypes.string,
+        choices: PropTypes.array.isRequired
+    };
+
+    onReplyClick = ({text, payload}) => {
+        Promise
+            .resolve()
+            .then(() => {
+                // animate the message
+            })
+            .then(() => sendMessage(text, {
+                payload
+            }));
+    };
+
+
+    render() {
+        const {choices, buttonColor} = this.props;
+
+        const buttonStyle = {};
+
+        if (buttonColor) {
+            const rgb = getRGB(`#${buttonColor}`);
+            const {h} = rgbToHsl(...rgb);
+            buttonStyle.backgroundColor = `hsl(${h}, 100%, 95%)`;
+            buttonStyle.borderColor = `#${buttonColor}`;
+            buttonStyle.color = `#${buttonColor}`;
+        }
+
+        const items = choices.map(({text, payload, iconUrl} , index) => {
+            const onClick = (e) => {
+                e.preventDefault();
+                this.onReplyClick({
+                    text,
+                    payload
+                });
+            };
+
+            const icon = iconUrl ?
+                <img className='sk-quick-reply-icon'
+                     src={ iconUrl } /> :
+                null;
+
+            return <button className='btn btn-sk-quick-reply'
+                           style={ buttonStyle }
+                           onClick={ onClick }
+                           key={ index }>
+                       { icon }
+                       { text }
+                   </button>;
+        });
+
+        return <div className='sk-quick-replies-container'>
+                   { items }
+               </div>;
+    }
+}
+
+export const QuickReplies = connect(({app}) => {
+    return {
+        buttonColor: app.settings.web.linkColor
+    };
+})(QuickRepliesComponent);

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -1,89 +1,67 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { MessageComponent } from './message';
 import { sendMessage } from '../services/conversation-service';
 import { getRGB, rgbToHsl } from '../utils/colors';
 
 export class QuickRepliesComponent extends Component {
     static propTypes = {
-        buttonColor: PropTypes.string,
+        linkColor: PropTypes.string.isRequired,
+        isLinkColorDark: PropTypes.bool.isRequired,
         choices: PropTypes.array.isRequired
     };
 
-    state = {
-        isSendingMessage: false
+    onReplyClick = ({text, payload}) => {
+        sendMessage(text, {
+            payload
+        });
     };
-
-    onReplyClick = ({text, payload, index}) => {
-        Promise
-            .resolve()
-            .then(() => {
-                this.setState({
-                    isSendingMessage: true,
-                    sendingChoiceIndex: index
-                })
-            });
-    // .then(() => sendMessage(text, {
-    //     payload
-    // }));
-    };
-
-
 
     render() {
-        const {choices, buttonColor} = this.props;
-        const {isSendingMessage, sendingChoiceIndex} = this.state;
-        if (isSendingMessage) {
-            const choice = choices[sendingChoiceIndex];
-            return <MessageComponent text={ choice.text }
-                            role='appUser'
-                            firstInGroup={ true }
-                            lastInGroup={ true } />;
-        } else {
-            const buttonStyle = {};
+        const {choices, linkColor, isLinkColorDark} = this.props;
 
-            if (buttonColor) {
-                const rgb = getRGB(`#${buttonColor}`);
-                const {h} = rgbToHsl(...rgb);
-                buttonStyle.backgroundColor = `hsl(${h}, 100%, 95%)`;
-                buttonStyle.borderColor = `#${buttonColor}`;
-                buttonStyle.color = `#${buttonColor}`;
-            }
+        const buttonStyle = {};
 
-            const items = choices.map(({text, payload, iconUrl} , index) => {
-                const onClick = (e) => {
-                    e.preventDefault();
-                    this.onReplyClick({
-                        text,
-                        payload,
-                        index
-                    });
-                };
-
-                const icon = iconUrl ?
-                    <img className='sk-quick-reply-icon'
-                         src={ iconUrl } /> :
-                    null;
-
-                return <button className='btn btn-sk-quick-reply'
-                               style={ buttonStyle }
-                               onClick={ onClick }
-                               key={ index }>
-                           { icon }
-                           { text }
-                       </button>;
-            });
-
-            return <div className='sk-quick-replies-container'>
-                       { items }
-                   </div>;
+        if (linkColor) {
+            const rgb = getRGB(`#${linkColor}`);
+            const {h} = rgbToHsl(...rgb);
+            buttonStyle.backgroundColor = isLinkColorDark ? `hsl(${h}, 100%, 95%)` : `hsl(${h}, 100%, 98%)`;
+            buttonStyle.borderColor = `#${linkColor}`;
+            buttonStyle.color = `#${linkColor}`;
         }
+
+        const items = choices.map(({text, payload, iconUrl} , index) => {
+            const onClick = (e) => {
+                e.preventDefault();
+                this.onReplyClick({
+                    text,
+                    payload
+                });
+            };
+
+            const icon = iconUrl ?
+                <img className='sk-quick-reply-icon'
+                     src={ iconUrl } /> :
+                null;
+
+            return <button className='btn btn-sk-quick-reply'
+                           style={ buttonStyle }
+                           onClick={ onClick }
+                           key={ index }>
+                       { icon }
+                       { text }
+                   </button>;
+        });
+
+        return <div className='sk-quick-replies-container'>
+                   { items }
+               </div>;
     }
 }
 
 export const QuickReplies = connect(({app}) => {
     return {
-        buttonColor: app.settings.web.linkColor
+        linkColor: app.settings.web.linkColor,
+        isLinkColorDark: app.settings.web.isLinkColorDark
     };
 })(QuickRepliesComponent);

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -6,7 +6,7 @@ import { getRGB, rgbToHsl } from '../utils/colors';
 
 export class QuickRepliesComponent extends Component {
     static propTypes = {
-        linkColor: PropTypes.string.isRequired,
+        accentColor: PropTypes.string.isRequired,
         isLinkColorDark: PropTypes.bool.isRequired,
         choices: PropTypes.array.isRequired
     };
@@ -18,16 +18,16 @@ export class QuickRepliesComponent extends Component {
     };
 
     render() {
-        const {choices, linkColor, isLinkColorDark} = this.props;
+        const {choices, accentColor, isLinkColorDark} = this.props;
 
         const buttonStyle = {};
 
-        if (linkColor) {
-            const rgb = getRGB(`#${linkColor}`);
+        if (accentColor) {
+            const rgb = getRGB(`#${accentColor}`);
             const {h} = rgbToHsl(...rgb);
             buttonStyle.backgroundColor = isLinkColorDark ? `hsl(${h}, 100%, 95%)` : `hsl(${h}, 100%, 98%)`;
-            buttonStyle.borderColor = `#${linkColor}`;
-            buttonStyle.color = `#${linkColor}`;
+            buttonStyle.borderColor = `#${accentColor}`;
+            buttonStyle.color = `#${accentColor}`;
         }
 
         const items = choices.map(({text, payload, iconUrl} , index) => {
@@ -61,7 +61,7 @@ export class QuickRepliesComponent extends Component {
 
 export const QuickReplies = connect(({app}) => {
     return {
-        linkColor: app.settings.web.linkColor,
+        accentColor: app.settings.web.accentColor,
         isLinkColorDark: app.settings.web.isLinkColorDark
     };
 })(QuickRepliesComponent);

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -6,8 +6,8 @@ import { getRGB, rgbToHsl } from '../utils/colors';
 
 export class QuickRepliesComponent extends Component {
     static propTypes = {
-        accentColor: PropTypes.string.isRequired,
-        isLinkColorDark: PropTypes.bool.isRequired,
+        accentColor: PropTypes.string,
+        isAccentColorDark: PropTypes.bool,
         choices: PropTypes.array.isRequired
     };
 
@@ -18,14 +18,14 @@ export class QuickRepliesComponent extends Component {
     };
 
     render() {
-        const {choices, accentColor, isLinkColorDark} = this.props;
+        const {choices, accentColor, isAccentColorDark} = this.props;
 
         const buttonStyle = {};
 
         if (accentColor) {
             const rgb = getRGB(`#${accentColor}`);
             const {h} = rgbToHsl(...rgb);
-            buttonStyle.backgroundColor = isLinkColorDark ? `hsl(${h}, 100%, 95%)` : `hsl(${h}, 100%, 98%)`;
+            buttonStyle.backgroundColor = isAccentColorDark ? `hsl(${h}, 100%, 95%)` : `hsl(${h}, 100%, 98%)`;
             buttonStyle.borderColor = `#${accentColor}`;
             buttonStyle.color = `#${accentColor}`;
         }
@@ -62,6 +62,6 @@ export class QuickRepliesComponent extends Component {
 export const QuickReplies = connect(({app}) => {
     return {
         accentColor: app.settings.web.accentColor,
-        isLinkColorDark: app.settings.web.isLinkColorDark
+        isAccentColorDark: app.settings.web.isAccentColorDark
     };
 })(QuickRepliesComponent);

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -63,4 +63,6 @@ export const QuickReplies = connect(({app}) => {
         accentColor: app.settings.web.accentColor,
         isAccentColorDark: app.settings.web.isAccentColorDark
     };
+}, null, null, {
+    withRef: true
 })(QuickRepliesComponent);

--- a/src/js/components/quick-replies.jsx
+++ b/src/js/components/quick-replies.jsx
@@ -48,8 +48,7 @@ export class QuickRepliesComponent extends Component {
                            style={ buttonStyle }
                            onClick={ onClick }
                            key={ index }>
-                       { icon }
-                       { text }
+                       <span>{ icon } { text }</span>
                    </button>;
         });
 

--- a/src/js/reducers/app-reducer.js
+++ b/src/js/reducers/app-reducer.js
@@ -44,7 +44,7 @@ function computeColorsMetadata(settings) {
             metadata[metadataKey] = isDefaultDark;
         }
     });
-    
+
     return metadata;
 }
 

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -32,13 +32,19 @@ const addMessage = (messages, message) => {
         const previousMessage = messages[messagesLength - 1];
         const messageAuthor = message.role === 'appUser' ? message.role : message.name;
         const previousMessageAuthor = previousMessage.role === 'appUser' ? previousMessage.role : previousMessage.name;
-        if (messageAuthor !== previousMessageAuthor) {
+
+        if (previousMessage.role !== message.role) {
+            previousMessage.lastInGroup = true;
             message.firstInGroup = true;
-            message.lastInGroup = true;
         } else {
-            message.lastInGroup = true;
-            previousMessage.lastInGroup = false;
-            messages[messagesLength - 1] = previousMessage;
+            if (messageAuthor !== previousMessageAuthor) {
+                message.firstInGroup = true;
+                message.lastInGroup = true;
+            } else {
+                message.lastInGroup = true;
+                previousMessage.lastInGroup = false;
+                messages[messagesLength - 1] = previousMessage;
+            }
         }
     } else {
         message.firstInGroup = true;

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -36,6 +36,7 @@ const addMessage = (messages, message) => {
         if (previousMessage.role !== message.role) {
             previousMessage.lastInGroup = true;
             message.firstInGroup = true;
+            message.lastInGroup = true;
         } else {
             if (messageAuthor !== previousMessageAuthor) {
                 message.firstInGroup = true;

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -92,7 +92,7 @@ const removeDuplicates = (messages) => {
 const assignGroups = (messages) => {
     let lastAuthor;
     messages.forEach((message, index) => {
-        const author = message.role === 'appUser' ? message.role : message.name;
+        const author = message.role === 'appUser' || !message.name ? message.role : message.name;
 
         if (!lastAuthor) {
             lastAuthor = author;

--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -94,10 +94,11 @@ const replaceMessage = (messages, query, newMessage) => {
     return [...messages.slice(0, index), newMessage, ...messages.slice(index + 1)];
 };
 
-const removeDuplicatesAndEmptyMessages = (messages) => {
+const cleanUpMessages = (messages) => {
     const cleanedMessages = [];
     const messagesHash = {};
 
+    // removes duplicate messages and empty messages 
     messages.forEach((message) => {
         const key = message._id + message.role + message.mediaType;
         const hasText = (message.text && !!message.text.trim()) || (message.mediaUrl && !!message.mediaUrl.trim());
@@ -132,13 +133,13 @@ export function ConversationReducer(state = INITIAL_STATE, action) {
         case ConversationActions.SET_MESSAGES:
             return {
                 ...state,
-                messages: assignGroups(sortMessages(removeDuplicatesAndEmptyMessages(action.messages))),
+                messages: assignGroups(sortMessages(cleanUpMessages(action.messages))),
                 quickReplies: extractQuickReplies(action.messages[action.messages.length - 1])
             };
         case ConversationActions.ADD_MESSAGES:
             return {
                 ...state,
-                messages: assignGroups(sortMessages(removeDuplicatesAndEmptyMessages(action.append ?
+                messages: assignGroups(sortMessages(cleanUpMessages(action.append ?
                     [...state.messages, ...action.messages] :
                     [...action.messages, ...state.messages]
                 ))),

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -75,14 +75,15 @@ export function sendChain(sendFn) {
         .then(connectFayeConversation);
 }
 
-export function sendMessage(text) {
+export function sendMessage(text, extra = {}) {
     return sendChain(() => {
         const message = {
             role: 'appUser',
             text,
             _clientId: Math.random(),
             _clientSent: new Date(),
-            deviceId: getDeviceId()
+            deviceId: getDeviceId(),
+            ...extra
         };
 
         store.dispatch(setShouldScrollToBottom(true));

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -37,3 +37,69 @@ export function isDark(colorCode) {
     var yiq = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000;
     return yiq < 128;
 }
+
+// extracted from https://bgrins.github.io/TinyColor/docs/tinycolor.html, MIT LICENSE
+export function rgbToHsl(r, g, b) {
+    const isPercentage = (n) => {
+        return typeof n === 'string' && n.indexOf('%') != -1;
+    };
+
+    const isOnePointZero = (n) => {
+        return typeof n == 'string' && n.indexOf('.') != -1 && parseFloat(n) === 1;
+    };
+
+    const bound01 = (n, max) => {
+        if (isOnePointZero(n)) {
+            n = '100%';
+        }
+
+        var processPercent = isPercentage(n);
+        n = Math.min(max, Math.max(0, parseFloat(n)));
+        if (processPercent) {
+            n = parseInt(n * max, 10) / 100;
+        }
+
+        if ( (Math.abs(n - max) < 0.000001) ) {
+            return 1;
+        }
+
+        return (n % max) / parseFloat(max);
+    };
+
+
+    r = bound01(r, 255);
+    g = bound01(g, 255);
+    b = bound01(b, 255);
+
+    var max = Math.max(r, g, b),
+        min = Math.min(r, g, b);
+    var h,
+        s,
+        l = (max + min) / 2;
+
+    if (max == min) {
+        h = s = 0; // achromatic
+    } else {
+        var d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+            case r:
+                h = (g - b) / d + (g < b ? 6 : 0);
+                break;
+            case g:
+                h = (b - r) / d + 2;
+                break;
+            case b:
+                h = (r - g) / d + 4;
+                break;
+        }
+
+        h /= 6;
+    }
+
+    return {
+        h: h * 360,
+        s: s * 100,
+        l: l * 100
+    };
+}

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -105,12 +105,46 @@ export function getElementProperties(element) {
 
 export function getTop(node, container = document.body) {
     let top = 0;
-    if (node && node.offsetParent) {
+    if (node && node.parentNode) {
         do {
             top += node.offsetTop;
-            node = node.offsetParent;
+            node = node.parentNode;
         } while (node && node !== container);
 
         return top;
     }
+}
+
+export function getBoundingRect(element) {
+    const style = window.getComputedStyle(element, null);
+    const margin = {
+        left: parseInt(style['margin-left']),
+        right: parseInt(style['margin-right']),
+        top: parseInt(style['margin-top']),
+        bottom: parseInt(style['margin-bottom'])
+    };
+    const padding = {
+        left: parseInt(style['padding-left']),
+        right: parseInt(style['padding-right']),
+        top: parseInt(style['padding-top']),
+        bottom: parseInt(style['padding-bottom'])
+    };
+    const border = {
+        left: parseInt(style['border-left']),
+        right: parseInt(style['border-right']),
+        top: parseInt(style['border-top']),
+        bottom: parseInt(style['border-bottom'])
+    };
+
+
+    var rect = element.getBoundingClientRect();
+    rect = {
+        left: rect.left - margin.left,
+        right: rect.right - margin.right - padding.left - padding.right,
+        top: rect.top - margin.top,
+        bottom: rect.bottom - margin.bottom - padding.top - padding.bottom - border.bottom
+    };
+    rect.width = rect.right - rect.left;
+    rect.height = rect.bottom - rect.top;
+    return rect;
 }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -105,10 +105,10 @@ export function getElementProperties(element) {
 
 export function getTop(node, container = document.body) {
     let top = 0;
-    if (node && node.parentNode) {
+    if (node && node.offsetParent) {
         do {
             top += node.offsetTop;
-            node = node.parentNode;
+            node = node.offsetParent;
         } while (node && node !== container);
 
         return top;

--- a/src/stylesheets/buttons.less
+++ b/src/stylesheets/buttons.less
@@ -107,3 +107,7 @@ a.btn {
         }
     }
 }
+
+.btn-sk-quick-reply {
+    .btn-sk-primary();
+}

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -106,6 +106,10 @@
                 &.sk-msg-appmaker-last {
                     border-top-left-radius: 2px;
                     margin-bottom: 3px;
+
+                    &.sk-msg-has-quick-replies {
+                        margin-bottom: 10px;
+                    }
                 }
                 &.sk-msg-appuser-first {
                     border-bottom-right-radius: 2px;

--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -270,7 +270,7 @@
     .scrollbar-mixin();
 
     .sk-logo {
-        margin-bottom: 10px;
+        padding-bottom: 10px;
         margin-left: @logo-margin;
 
         a {

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -31,6 +31,7 @@
     @import "header.less";
     @import "notification.less";
     @import "conversation.less";
+    @import "quick-replies.less";
     @import "footer.less";
     @import "settings.less";
     @import "channels.less";

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -1,0 +1,19 @@
+.sk-quick-replies-container {
+    padding-bottom: 5px;
+
+    .btn-sk-quick-reply {
+        padding: 3px 7px 4px;
+        border-radius: 7px;
+        border: 1px solid @sk-blue;
+        line-height: 20px;
+        display: inline-block;
+        margin-left: 5px;
+        color: @sk-darker-grey;
+
+        .sk-quick-reply-icon {
+            height: 20px;
+            vertical-align: bottom;
+            margin-right: 5px;
+        }
+    }
+}

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -9,6 +9,8 @@
         display: inline-block;
         margin-left: 5px;
         color: @sk-darker-grey;
+        margin-bottom: 5px;
+        float: right;
 
         .sk-quick-reply-icon {
             height: 20px;

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -1,5 +1,8 @@
 .sk-quick-replies-container {
     padding-bottom: 5px;
+    text-align: right;
+    position: relative;
+    display: block;
 
     .btn-sk-quick-reply {
         padding: 3px 7px 4px;
@@ -10,7 +13,6 @@
         margin-left: 5px;
         color: @sk-darker-grey;
         margin-bottom: 5px;
-        float: right;
 
         .sk-quick-reply-icon {
             height: 20px;

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -1,5 +1,5 @@
 .sk-quick-replies-container {
-    padding-bottom: 5px;
+    margin-bottom: 5px;
     text-align: right;
     position: relative;
     display: block;

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -1,9 +1,8 @@
 .sk-quick-replies-container {
-    margin-bottom: 5px;
     text-align: right;
     position: relative;
     display: block;
-    padding-bottom: 5px;
+    padding-bottom: 10px;
 
     .btn-sk-quick-reply {
         padding: 3px 7px 4px;

--- a/src/stylesheets/quick-replies.less
+++ b/src/stylesheets/quick-replies.less
@@ -3,6 +3,7 @@
     text-align: right;
     position: relative;
     display: block;
+    padding-bottom: 5px;
 
     .btn-sk-quick-reply {
         padding: 3px 7px 4px;
@@ -14,10 +15,18 @@
         color: @sk-darker-grey;
         margin-bottom: 5px;
 
-        .sk-quick-reply-icon {
-            height: 20px;
-            vertical-align: bottom;
-            margin-right: 5px;
+        span {
+            max-width: 280px;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            display: block;
+            white-space: nowrap;
+
+            .sk-quick-reply-icon {
+                height: 20px;
+                vertical-align: bottom;
+                margin-right: 5px;
+            }
         }
     }
 }

--- a/test/specs/components/action.spec.js
+++ b/test/specs/components/action.spec.js
@@ -22,7 +22,7 @@ function getNormalProps(props = {}) {
         _id: 'action id',
         type: 'link',
         text: 'action text',
-        uri: 'action uri'
+        uri: 'http://some-uri/'
     };
 
     return Object.assign(defaultProps, props);
@@ -33,7 +33,7 @@ function getBuyProps(props = {}) {
         _id: 'action id',
         type: 'buy',
         text: 'action text',
-        uri: 'action uri',
+        uri: 'http://some-uri/',
         currency: 'usd',
         state: 'offered'
     };
@@ -114,9 +114,9 @@ describe('Action Component', () => {
 
         it('should render a link with target blank', () => {
             const link = TestUtils.findRenderedDOMComponentWithTag(component, 'a');
-            link.textContent = 'action text';
-            link.href = 'action uri';
-            link.target = '_blank';
+            link.textContent.should.eq('action text');
+            link.href.should.eq('http://some-uri/');
+            link.target.should.eq('_blank');
         });
     });
 
@@ -133,9 +133,9 @@ describe('Action Component', () => {
 
         it('should render a link with target self', () => {
             const link = TestUtils.findRenderedDOMComponentWithTag(component, 'a');
-            link.textContent = 'action text';
-            link.href = 'javascript:someAction()';
-            link.target = '_self';
+            link.textContent.should.eq('action text');
+            link.href.should.eq('javascript:someAction()');
+            link.target.should.eq('_self');
         });
     });
 
@@ -165,7 +165,7 @@ describe('Action Component', () => {
 
         describe('buy action with stripe keys and offered state', () => {
             const props = getBuyProps({
-                uri: 'fallback uri'
+                uri: 'http://some-fallback-uri/'
             });
 
             beforeEach(() => {
@@ -380,9 +380,9 @@ describe('Action Component', () => {
 
         it('should render a link', () => {
             const link = TestUtils.findRenderedDOMComponentWithTag(component, 'a');
-            link.textContent = 'action text';
-            link.href = 'fallback uri';
-            link.target = '_blank';
+            link.textContent.should.eq('action text');
+            link.href.should.eq('http://some-uri/');
+            link.target.should.eq('_blank');
         });
     });
 

--- a/test/specs/components/conversation.spec.js
+++ b/test/specs/components/conversation.spec.js
@@ -38,19 +38,23 @@ function getStoreState(state = {}) {
             messages: [
                 {
                     _id: 1,
-                    received: 1
+                    received: 1,
+                    role: 'appMaker'
                 },
                 {
                     _id: 2,
-                    received: 2
+                    received: 2,
+                    role: 'appMaker'
                 },
                 {
                     _id: 3,
-                    received: 3
+                    received: 3,
+                    role: 'appMaker'
                 },
                 {
                     _id: 4,
-                    received: 4
+                    received: 4,
+                    role: 'appMaker'
                 }
             ],
             hasMoreMessages: false

--- a/test/specs/components/conversation.spec.js
+++ b/test/specs/components/conversation.spec.js
@@ -6,6 +6,7 @@ import { Conversation } from '../../../src/js/components/conversation';
 import { MessageComponent } from '../../../src/js/components/message';
 import { Introduction } from '../../../src/js/components/introduction';
 import { ConnectNotification } from '../../../src/js/components/connect-notification';
+import { QuickReplies } from '../../../src/js/components/quick-replies';
 
 import { mockComponent, wrapComponentWithStore } from '../../utils/react';
 import { mockAppStore } from '../../utils/redux';
@@ -80,6 +81,9 @@ describe('Conversation Component', () => {
         mockComponent(sandbox, ConnectNotification, 'div', {
             className: 'mockedConnectNotification'
         });
+        mockComponent(sandbox, QuickReplies, 'div', {
+            className: 'mockedQuickReplies'
+        });
 
         mockedStore = mockAppStore(sandbox, getStoreState());
     });
@@ -100,6 +104,10 @@ describe('Conversation Component', () => {
 
         it('should render introduction text', () => {
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedIntroduction').length.should.eq(1);
+        });
+
+        it('should not render quick replies', () => {
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedQuickReplies').length.should.eq(0);
         });
     });
 
@@ -133,6 +141,53 @@ describe('Conversation Component', () => {
                     TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedIntroduction').length.should.eq(hasMoreMessages ? 0 : 1);
                 });
             });
+        });
+    });
+
+    describe('Quick Replies', () => {
+        beforeEach(() => {
+            mockedStore = mockAppStore(sandbox, getStoreState({
+                conversation: {
+                    messages: [
+                        {
+                            _id: 1,
+                            received: 1,
+                            role: 'appMaker'
+                        },
+                        {
+                            _id: 2,
+                            received: 2,
+                            role: 'appMaker'
+                        },
+                        {
+                            _id: 3,
+                            received: 3,
+                            role: 'appMaker'
+                        },
+                        {
+                            _id: 4,
+                            received: 4,
+                            role: 'appMaker'
+                        },
+                        {
+                            _id: 5,
+                            received: 5,
+                            role: 'appMaker',
+                            actions: [
+                                {
+                                    type: 'reply',
+                                    text: 'reply'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }));
+            component = wrapComponentWithStore(Conversation, null, mockedStore);
+        });
+
+        it('should render quick replies', () => {
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedQuickReplies').length.should.eq(1);            
         });
     });
 });

--- a/test/specs/components/conversation.spec.js
+++ b/test/specs/components/conversation.spec.js
@@ -58,6 +58,7 @@ function getStoreState(state = {}) {
                     role: 'appMaker'
                 }
             ],
+            quickReplies: [],
             hasMoreMessages: false
         }
     };
@@ -180,6 +181,12 @@ describe('Conversation Component', () => {
                                 }
                             ]
                         }
+                    ],
+                    quickReplies: [
+                        {
+                            type: 'reply',
+                            text: 'reply'
+                        }
                     ]
                 }
             }));
@@ -187,7 +194,7 @@ describe('Conversation Component', () => {
         });
 
         it('should render quick replies', () => {
-            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedQuickReplies').length.should.eq(1);            
+            TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedQuickReplies').length.should.eq(1);
         });
     });
 });

--- a/test/specs/components/message.spec.js
+++ b/test/specs/components/message.spec.js
@@ -59,7 +59,7 @@ describe('Message Component', () => {
             const props = {
                 role: 'appUser',
                 text: 'This is a text!',
-                mediaUrl: isImage ? 'media-url' : false
+                mediaUrl: isImage ? 'media-url' : undefined
             };
 
             beforeEach(() => {

--- a/test/specs/components/quick-replies.spec.js
+++ b/test/specs/components/quick-replies.spec.js
@@ -1,0 +1,73 @@
+import sinon from 'sinon';
+import TestUtils from 'react-addons-test-utils';
+
+import { mockAppStore } from '../../utils/redux';
+import { wrapComponentWithStore } from '../../utils/react';
+import { QuickReplies } from '../../../src/js/components/quick-replies';
+
+const conversationService = require('../../../src/js/services/conversation-service');
+
+
+describe('QuickReplies Component', () => {
+    let mockedStore;
+    let component;
+    const sandbox = sinon.sandbox.create();
+    const CHOICES = [
+        {
+            text: 'choice 1',
+            payload: 'payload 1'
+        },
+        {
+            text: 'choice 2',
+            payload: 'payload 2',
+            iconUrl: 'http://some-url/'
+        }
+    ];
+
+    beforeEach(() => {
+        mockedStore = mockAppStore(sandbox, {
+            app: {
+                settings: {
+                    web: {
+                        accentColor: '',
+                        isAccentColorDark: true
+                    }
+                }
+            }
+        });
+        sandbox.stub(conversationService, 'sendMessage');
+
+        component = wrapComponentWithStore(QuickReplies, {
+            choices: CHOICES
+        }, mockedStore).getWrappedInstance();
+    });
+
+    afterEach(() => {
+        mockedStore && mockedStore.restore();
+        sandbox.restore();
+    });
+
+    it('should render choices', () => {
+        TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-quick-reply').forEach((node, index) => {
+            const choice = CHOICES[index];
+            node.textContent.trim().should.eq(choice.text);
+
+            if (choice.iconUrl) {
+                const icon = node.querySelector('img');
+                icon.src.should.eq(choice.iconUrl);
+            } else {
+                node.querySelectorAll('img').length.should.eq(0);
+            }
+        });
+    });
+
+    it('should call sendMessage with payload when clicked', () => {
+        TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-quick-reply').forEach((node, index) => {
+            const choice = CHOICES[index];
+            TestUtils.Simulate.click(node);
+            conversationService.sendMessage.should.have.been.calledWith(choice.text, {
+                payload: choice.payload
+            });
+        });
+    });
+});


### PR DESCRIPTION
Soooo, quick replies!

Here's basically how this works : 
- When a message is dispatched to the store, the reducer will extract the quick replies (if present) from it and store them in the store's state. If the message only has quick replies without any text, it's discarded and only the replies are kept.
- From that list of replies, the conversation component figures out if it should show the QuickReplies component or not
- Only the last set of quick replies is shown to the user (hence why I extract them when receiving the message)
- Actions of type `reply` can't be mixed with other action type, so don't worry about it.


@mspensieri @jugarrit @dannytranlx @hebime 