### PR TITLE
Fix filter url generation

### DIFF
--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -1,14 +1,10 @@
 import React, { Component, PropTypes } from 'react';
-import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 
 import { openWidget } from '../services/app-service';
 import { SK_DARK_CONTRAST } from '../constants/styles';
 
 export class DefaultButtonIcon extends Component {
-    componentDidMount() {
-        this._pathNode.filter = this._pathNode.filter;
-    }
 
     render() {
         const {isBrandColorDark} = this.props;
@@ -38,8 +34,7 @@ export class DefaultButtonIcon extends Component {
                            <feMergeNode in='SourceGraphic' />
                        </feMerge>
                    </filter>
-                   <path ref={ (c) => this._pathNode = findDOMNode(c) }
-                         fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
+                   <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
                          filter={ `url(${protocol}//${host}${pathname}${search}#dropShadow)` }
                          d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
                </svg>;

--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -1,12 +1,19 @@
 import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 
 import { openWidget } from '../services/app-service';
 import { SK_DARK_CONTRAST } from '../constants/styles';
 
 export class DefaultButtonIcon extends Component {
+    componentDidMount() {
+        this._pathNode.filter = this._pathNode.filter;
+    }
+
     render() {
         const {isBrandColorDark} = this.props;
+
+        const {protocol, host, pathname, search} = window.location;
 
         return <svg version='1.0'
                     x='0px'
@@ -31,8 +38,9 @@ export class DefaultButtonIcon extends Component {
                            <feMergeNode in='SourceGraphic' />
                        </feMerge>
                    </filter>
-                   <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
-                         filter={`url(${window.location}#dropShadow)`}
+                   <path ref={ (c) => this._pathNode = findDOMNode(c) }
+                         fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
+                         filter={ `url(${protocol}//${host}${pathname}${search}#dropShadow)` }
                          d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
                </svg>;
     }


### PR DESCRIPTION
Last attempt at fixing the `filter url()` problem with `<base href />` didn't go too well. The previous logic would crash pages that are using hashes already as reported by https://github.com/smooch/smooch-js/issues/390#issuecomment-259639675.

This time, the url is regenerating from `window.location` and omits only the hash. After couple of tests, keeping the querystring was necessary too.

@mspensieri @jugarrit @dannytranlx 