### PR TITLE
Fix SET_CONVERSATION regression

### DIFF
--- a/src/js/reducers/conversation-reducer.js
+++ b/src/js/reducers/conversation-reducer.js
@@ -98,7 +98,7 @@ const cleanUpMessages = (messages) => {
     const cleanedMessages = [];
     const messagesHash = {};
 
-    // removes duplicate messages and empty messages 
+    // removes duplicate messages and empty messages
     messages.forEach((message) => {
         const key = message._id + message.role + message.mediaType;
         const hasText = (message.text && !!message.text.trim()) || (message.mediaUrl && !!message.mediaUrl.trim());
@@ -127,8 +127,8 @@ export function ConversationReducer(state = INITIAL_STATE, action) {
             };
         case ConversationActions.SET_CONVERSATION:
             return {
-                ...INITIAL_STATE,
-                ...action.conversation
+                ...action.conversation,
+                messages: state.messages
             };
         case ConversationActions.SET_MESSAGES:
             return {


### PR DESCRIPTION
In #431, a regression was introduced where SET_CONVERSATION would override the current messages which would cause a flicker on the first message.

I think the change was linked to some preliminary try to implement quick replies and ended not being useful.


@mspensieri @dannytranlx @jugarrit 