### PR TITLE
Add condition to display Viber deep link for mobiles

### DIFF
--- a/src/js/constants/channels.js
+++ b/src/js/constants/channels.js
@@ -56,7 +56,8 @@ export const CHANNEL_DETAILS = {
         ...integrationsAssets.viber,
         Component: !isMobile.any ? ViberChannelContent : undefined,
         onChannelPage: fetchViberQRCode,
-        getURL: (appUser, channel) => `viber://pa?chatURI=${channel.uri}&context=${appUser.id}`
+        getURL: (appUser, channel) => isMobile.any ? `viber://pa?chatURI=${channel.uri}&context=${appUser._id}` : undefined,
+        renderPageIfLinked: !isMobile.any
     },
     wechat: {
         name: 'WeChat',


### PR DESCRIPTION
Since `getURL` was defined on desktop mode, it was putting the deep link and that was failing to load on browsers. Adding `renderPageIfLinked` will display the QR code again instead.

@lemieux @jugarrit @hebime @wmora 