### PR TITLE
Add Connected text without display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ var skPromise = Smooch.init({
         notificationSettingsChannelsTitle: 'Other Channels',
         notificationSettingsChannelsDescription: 'You can also talk to us from your favorite app or service.',
         notificationSettingsConnectedAs: 'Connected as {username}',
+        notificationSettingsConnected: 'Connected',
         wechatQRCodeError: 'An error occurred while fetching your WeChat QR code. Please try again.',
         messengerChannelDescription: 'Connect your Facebook Messenger account to be notified when you get a reply and carry the conversation on Facebook Messenger.',
         frontendEmailChannelDescription: 'To talk to us using email just send a message to our email address and we\'ll reply shortly:',

--- a/src/js/components/notification-channel-item.jsx
+++ b/src/js/components/notification-channel-item.jsx
@@ -13,7 +13,8 @@ export class NotificationChannelItemComponent extends Component {
         icon2x: PropTypes.string.isRequired,
         displayName: PropTypes.string,
         linkColor: PropTypes.string,
-        notificationSettingsConnectedAsText: PropTypes.string.isRequired
+        notificationSettingsConnectedAsText: PropTypes.string.isRequired,
+        notificationSettingsConnectedText: PropTypes.string.isRequired
     };
 
     onClick = () => {
@@ -21,7 +22,7 @@ export class NotificationChannelItemComponent extends Component {
     };
 
     render() {
-        const {name, icon, icon2x, linked, hasURL, displayName, linkColor, notificationSettingsConnectedAsText} = this.props;
+        const {name, icon, icon2x, linked, hasURL, displayName, linkColor, notificationSettingsConnectedText, notificationSettingsConnectedAsText} = this.props;
 
         const itemRightStyle = linked && linkColor ? {
             color: `#${linkColor}`
@@ -46,7 +47,7 @@ export class NotificationChannelItemComponent extends Component {
                                { name }
                            </div>
                            { linked ? <div className='channel-item-connected-as'>
-                                          { notificationSettingsConnectedAsText.replace('{username}', displayName) }
+                                          { displayName ? notificationSettingsConnectedAsText.replace('{username}', displayName) : notificationSettingsConnectedText }
                                       </div> : null }
                        </div>
                        <div className='channel-item-right'
@@ -61,6 +62,7 @@ export class NotificationChannelItemComponent extends Component {
 export const NotificationChannelItem = connect(({app, ui}) => {
     return {
         linkColor: app.settings.web.linkColor,
-        notificationSettingsConnectedAsText: ui.text.notificationSettingsConnectedAs
+        notificationSettingsConnectedAsText: ui.text.notificationSettingsConnectedAs,
+        notificationSettingsConnectedText: ui.text.notificationSettingsConnected
     };
 })(NotificationChannelItemComponent);

--- a/src/js/reducers/ui-reducer.js
+++ b/src/js/reducers/ui-reducer.js
@@ -25,6 +25,7 @@ const INITIAL_STATE = {
         notificationSettingsChannelsTitle: 'Other Channels',
         notificationSettingsChannelsDescription: 'You can also talk to us from your favorite app or service.',
         notificationSettingsConnectedAs: 'Connected as {username}',
+        notificationSettingsConnected: 'Connected',
         viberQRCodeError: 'An error occurred while fetching your Viber QR code. Please try again.',
         wechatQRCodeError: 'An error occurred while fetching your WeChat QR code. Please try again.',
         messengerChannelDescription: 'Connect your Facebook Messenger account to be notified when you get a reply and carry the conversation on Facebook Messenger.',

--- a/test/specs/components/notification-channel-item.spec.jsx
+++ b/test/specs/components/notification-channel-item.spec.jsx
@@ -39,6 +39,7 @@ describe('Notification Channel Item Component', () => {
                     ui: {
                         text: {
                             notificationSettingsConnectedAs: 'connected as'
+                            notificationSettingsConnected: 'connected'
                         }
                     }
                 });


### PR DESCRIPTION
Viber (or other clients) that doesn't have display names shouldn't try to display them.

@lemieux @jugarrit @hebime @wmora 