### PR TITLE
Render new lines in text messages

### DIFF
--- a/src/js/components/text-message.jsx
+++ b/src/js/components/text-message.jsx
@@ -11,7 +11,7 @@ export class TextMessage extends Component {
     render() {
         let text = this.props.text.split('\n').map((item, index) => {
             if (!item.trim()) {
-                return;
+                return <br key={ index } />;
             }
 
             const linkOptions = {


### PR DESCRIPTION
New lines or empty lines were just thrown out in messages. This will render a `<br/>` instead.

![image](https://cloud.githubusercontent.com/assets/781844/20634322/92c3f1ea-b31d-11e6-97b0-ba8550dfa228.png)


@mspensieri @dannytranlx 