### PR TITLE
Fixed use of setTimeout to avoid errors when dispatching custom actions

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -34,7 +34,7 @@ export class Observable {
             // use setTimeout to execute the handler after the current
             // execution stack is cleared. That way, any hooks won't block the
             // widget execution
-            map.get(event).forEach((handler) => setTimeout(handler(options)));
+            map.get(event).forEach((handler) => setTimeout(() => handler(options), 0));
         }
     }
 }


### PR DESCRIPTION
The implementation of setTimeout in utils/events is incorrect and then leading to some errors when trying to use advanced handlers.

Passing a function to setTimeout solves this issue.

Below is an example of error with the current implementation:

Uncaught TypeError: callback.apply is not a function
    at new_callback (http://localhost:8000/webpack:/~/longjohn/dist/longjohn.js:188:1)
---------------------------------------------
    at global.setTimeout (http://localhost:8000/webpack:/~/longjohn/dist/longjohn.js:289:1)
    at http://localhost:8000/webpack:/~/smooch/lib/utils/events.js:69:1
    at Set.forEach (native)
    at Set.<anonymous> (http://localhost:8000/webpack:/~/core-js/library/modules/_collection.js:40:1)
    at Observable.trigger (http://localhost:8000/webpack:/~/smooch/lib/utils/events.js:68:1)
    at openWidget (http://localhost:8000/webpack:/~/smooch/lib/services/app-service.js:54:1)
    at MessengerButtonComponent._this2.onClick (http://localhost:8000/webpack:/~/smooch/lib/components/messenger-button.js:101:1)
    at Object.ReactErrorUtils.invokeGuardedCallback (http://localhost:8000/webpack:/~/react-dom/lib/ReactErrorUtils.js:70:1)
    at executeDispatch (http://localhost:8000/webpack:/~/react-dom/lib/EventPluginUtils.js:85:1)
    at Object.executeDispatchesInOrder (http://localhost:8000/webpack:/~/react-dom/lib/EventPluginUtils.js:108:1)
    at executeDispatchesAndRelease (http://localhost:8000/webpack:/~/react-dom/lib/EventPluginHub.js:43:1)
    at executeDispatchesAndReleaseTopLevel (http://localhost:8000/webpack:/~/react-dom/lib/EventPluginHub.js:54:1)
    at Array.forEach (native)
    at forEachAccumulated (http://localhost:8000/webpack:/~/react-dom/lib/forEachAccumulated.js:24:1)
    at Object.processEventQueue (http://localhost:8000/webpack:/~/react-dom/lib/EventPluginHub.js:230:1)
    at runEventQueueInBatch (http://localhost:8000/webpack:/~/react-dom/lib/ReactEventEmitterMixin.js:17:1)