### PR TITLE
Fix round corners for single message

### DIFF
--- a/src/stylesheets/conversation.less
+++ b/src/stylesheets/conversation.less
@@ -81,7 +81,7 @@
         clear: both;
         padding-bottom: 0px;
         padding-top: 2px;
-        &.sk-row-appmaker-first {
+        &.sk-row-appmaker-first:not(.sk-row-appmaker-last) {
             .sk-msg-wrapper {
                 .sk-msg, .sk-msg-image {
                     border-bottom-left-radius: 2px;
@@ -96,7 +96,7 @@
                 }
             }
         }
-        &.sk-row-appmaker-last {
+        &.sk-row-appmaker-last:not(.sk-row-appmaker-first) {
             .sk-msg-wrapper {
                 .sk-msg, .sk-msg-image {
                     border-top-left-radius: 2px;
@@ -104,7 +104,8 @@
             }
             margin-bottom: 10px;
         }
-        &.sk-row-appuser-first {
+
+        &.sk-row-appuser-first:not(.sk-row-appuser-last) {
             .sk-msg-wrapper {
                 .sk-msg, .sk-msg-image {
                     border-bottom-right-radius: 2px;
@@ -119,7 +120,7 @@
                 }
             }
         }
-        &.sk-row-appuser-last {
+        &.sk-row-appuser-last:not(.sk-row-appuser-first) {
             .sk-msg-wrapper {
                 .sk-msg, .sk-msg-image {
                     border-top-right-radius: 2px;

--- a/test/specs/services/app-service.spec.js
+++ b/test/specs/services/app-service.spec.js
@@ -9,6 +9,7 @@ import { WIDGET_STATE } from '../../../src/js/constants/app';
 describe('App Service', () => {
     let mockedStore;
     let sandbox;
+    let clock;
     let openSpy;
     let closeSpy;
 
@@ -17,6 +18,7 @@ describe('App Service', () => {
     });
 
     beforeEach(() => {
+        clock = sandbox.useFakeTimers();
         openSpy = sandbox.spy();
         closeSpy = sandbox.spy();
 
@@ -45,6 +47,7 @@ describe('App Service', () => {
                 if (isEmbedded) {
                     it('should do nothing', () => {
                         openWidget();
+                        clock.tick(20);
                         mockedStore.dispatch.should.not.have.been.called;
                         openSpy.should.not.have.been.called;
                         closeSpy.should.not.have.been.called;
@@ -52,6 +55,7 @@ describe('App Service', () => {
                 } else {
                     it('should call dispatch with open action', () => {
                         openWidget();
+                        clock.tick(20);
                         mockedStore.dispatch.should.have.been.calledWith({
                             type: OPEN_WIDGET
                         });
@@ -65,6 +69,7 @@ describe('App Service', () => {
                 if (isEmbedded) {
                     it('should do nothing', () => {
                         closeWidget();
+                        clock.tick(20);
                         mockedStore.dispatch.should.not.have.been.called;
                         openSpy.should.not.have.been.called;
                         closeSpy.should.not.have.been.called;
@@ -72,6 +77,7 @@ describe('App Service', () => {
                 } else {
                     it('should call dispatch with close action', () => {
                         closeWidget();
+                        clock.tick(20);
                         mockedStore.dispatch.should.have.been.calledWith({
                             type: CLOSE_WIDGET
                         });
@@ -85,6 +91,7 @@ describe('App Service', () => {
                 if (isEmbedded) {
                     it('should do nothing', () => {
                         toggleWidget();
+                        clock.tick(20);
                         mockedStore.dispatch.should.not.have.been.called;
                         openSpy.should.not.have.been.called;
                         closeSpy.should.not.have.been.called;
@@ -104,6 +111,7 @@ describe('App Service', () => {
 
                             it(`should call dispatch with ${isOpened ? 'closed' : 'opened'} action`, () => {
                                 toggleWidget();
+                                clock.tick(20);
                                 if (isOpened) {
                                     mockedStore.dispatch.should.have.been.calledWith({
                                         type: CLOSE_WIDGET

--- a/test/specs/utils/events.spec.js
+++ b/test/specs/utils/events.spec.js
@@ -2,9 +2,14 @@ import sinon from 'sinon';
 
 import { Observable } from '../../../src/js/utils/events';
 
-const sandbox = sinon.sandbox.create();
 
 describe('Events utils', () => {
+    const sandbox = sinon.sandbox.create();
+    let clock;
+    beforeEach(() => {
+        clock = sandbox.useFakeTimers();
+    });
+
     afterEach(() => {
         sandbox.restore();
     });
@@ -23,6 +28,7 @@ describe('Events utils', () => {
             observable.on('2', thirdHandler);
             observable.on('2', fourthHandler);
             observable.trigger('1');
+            clock.tick(20);
 
             firstHandler.should.have.been.calledOnce;
             secondHandler.should.have.been.calledOnce;
@@ -35,6 +41,7 @@ describe('Events utils', () => {
             fourthHandler.reset();
 
             observable.trigger('2');
+            clock.tick(20);
             firstHandler.should.not.have.been.called;
             secondHandler.should.not.have.been.called;
             thirdHandler.should.have.been.calledOnce;
@@ -47,6 +54,7 @@ describe('Events utils', () => {
 
             observable.off('1', firstHandler);
             observable.trigger('1');
+            clock.tick(20);
 
             firstHandler.should.not.have.been.called;
             secondHandler.should.have.been.calledOnce;
@@ -60,6 +68,7 @@ describe('Events utils', () => {
 
             observable.off('2');
             observable.trigger('2');
+            clock.tick(20);
 
             firstHandler.should.not.have.been.called;
             secondHandler.should.not.have.been.calledOnce;
@@ -73,6 +82,7 @@ describe('Events utils', () => {
 
             observable.off();
             observable.trigger('1');
+            clock.tick(20);
 
             firstHandler.should.not.have.been.called;
             secondHandler.should.not.have.been.calledOnce;


### PR DESCRIPTION
Last fix #451 introduce a regression where messages that were not part of a group would be missing their round corners.

![image](https://cloud.githubusercontent.com/assets/781844/21430562/b5b25f2e-c831-11e6-922e-30fbd1a0394b.png)

This fixes it.

![image](https://cloud.githubusercontent.com/assets/781844/21430572/bf402e72-c831-11e6-9347-2b5cd18683fe.png)
