### PR TITLE
Fix image upload

### DIFF
--- a/release_notes/v3.9.3.md
+++ b/release_notes/v3.9.3.md
@@ -1,0 +1,3 @@
+# What's new?
+
+- A regression was fixed where image uploads would always fail with an "invalid extension" error.

--- a/src/js/components/message.jsx
+++ b/src/js/components/message.jsx
@@ -43,10 +43,9 @@ export class MessageComponent extends Component {
     }
 
     render() {
-        const {name, role, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor, type} = this.props;
+        const {name, role, avatarUrl, text, accentColor, firstInGroup, lastInGroup, linkColor, type, mediaUrl} = this.props;
         const actions = this.props.actions.filter((a) => a.type !== 'reply');
-
-        const hasText = text && text.trim();
+        const hasText = text && text.trim() && text.trim() !== mediaUrl;
         const hasImage = type === 'image';
         const isAppUser = role === 'appUser';
         const hasActions = actions.length > 0;

--- a/src/js/services/conversation-service.js
+++ b/src/js/services/conversation-service.js
@@ -128,6 +128,7 @@ export function uploadImage(file) {
                 mediaUrl: dataUrl,
                 mediaType: 'image/jpeg',
                 role: 'appUser',
+                type: 'image',
                 status: 'sending',
                 _clientId: Math.random(),
                 _clientSent: new Date()


### PR DESCRIPTION
Image upload messages were being created without an `image` type, and
were not correctly handled as images by the UI, causing the
`_restyleBubble` method to throw, and prevent the upload from going
through.

After fixing that issue, it revealed a rendering issue when the `text`
property of a message was equal to its `mediaUrl`, so I fixed that too.