### PR TITLE
Embed webpack server in dev server

### DIFF
--- a/config/default/config.json
+++ b/config/default/config.json
@@ -5,6 +5,5 @@
     "USER_ID": "",
     "GIVEN_NAME": "DEFAULT_NAME",
     "SURNAME": "DEFAULT_SURNAME",
-    "EMAIL": "DEFAULT@EMAIL.COM",
-    "SERVER_HOST": "localhost:2992"
+    "EMAIL": "DEFAULT@EMAIL.COM"
 }

--- a/dev-server/server.js
+++ b/dev-server/server.js
@@ -1,14 +1,13 @@
 module.exports = function(options) {
 
-    var express = require('express');
-    var bodyParser = require('body-parser');
-    var path = require('path');
+    const express = require('express');
+    const path = require('path');
 
     // require the page rendering logic
-    var Renderer = require('./SimpleRenderer.js');
+    const Renderer = require('./SimpleRenderer.js');
 
 
-    var config = require('../config/default/config.json');
+    const config = require('../config/default/config.json');
 
     try {
         Object.assign(config, require('../config/config.json'));
@@ -16,25 +15,31 @@ module.exports = function(options) {
     catch (e) {
         // do nothing
     }
-    var publicPath = options.devServer ?
-        'http://' + config.SERVER_HOST + '/_assets/' :
-        '/_assets/';
 
-    var app = express();
+    const app = express();
 
-    // serve the static assets
-    app.use('/_assets', express.static(path.join(__dirname, '..', 'dist'), {
-        maxAge: '200d' // We can cache them as they include hashes
-    }));
-    app.use('/', express.static(path.join(__dirname, '..', 'public'), {
-    }));
+    if (options.devServer) {
+        const webpack = require('webpack');
+        const config = require('../webpack-dev-server.config');
+        const compiler = webpack(config);
+        app.use(require('webpack-dev-middleware')(compiler, {
+            publicPath: '/_assets/',
+            quiet: true
+        }));
 
-    app.use(bodyParser.json());
-
+        app.use(require('webpack-hot-middleware')(compiler));
+    } else {
+        // serve the static assets
+        app.use('/_assets', express.static(path.join(__dirname, '..', 'dist'), {
+            maxAge: '200d' // We can cache them as they include hashes
+        }));
+        app.use('/', express.static(path.join(__dirname, '..', 'public'), {
+        }));
+    }
 
     app.get('/embedded', function(req, res) {
-        var renderer = new Renderer({
-            scriptUrl: publicPath + 'smooch.js',
+        const renderer = new Renderer({
+            scriptUrl: '/_assets/smooch.js',
             data: config,
             embedded: true
         });
@@ -55,8 +60,8 @@ module.exports = function(options) {
 
     // application
     app.get('/*', function(req, res) {
-        var renderer = new Renderer({
-            scriptUrl: publicPath + 'smooch.js',
+        const renderer = new Renderer({
+            scriptUrl: '/_assets/smooch.js',
             data: config
         });
 
@@ -75,7 +80,7 @@ module.exports = function(options) {
     });
 
 
-    var port = process.env.PORT || options.defaultPort || 8080;
+    const port = process.env.PORT || options.defaultPort || 8080;
     app.listen(port, function() {
         console.log('Server listening on port ' + port); //eslint-disable-line no-console
     });

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -50,7 +50,7 @@ module.exports = function(options) {
     var extensions = ['', '.web.js', '.js', '.jsx'];
     var root = path.join(__dirname, 'src');
     var publicPath = options.devServer ?
-        'http://' + config.SERVER_HOST + '/_assets/' :
+        '/_assets/' :
         'https://cdn.smooch.io/';
 
     var output = {
@@ -156,8 +156,6 @@ module.exports = function(options) {
         },
         plugins: plugins,
         devServer: {
-            host: config.SERVER_HOST.split(':')[0],
-            port: config.SERVER_HOST.split(':')[1],
             stats: {
                 cached: false,
                 exclude: excludeFromStats

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -18,15 +18,20 @@ module.exports = function(options) {
         // do nothing
     }
 
-    var entry = options.assetsOnly ? {
+    const entry = options.assetsOnly ? {
         assets: './src/js/constants/assets'
     } : {
         smooch: ['./src/js/utils/polyfills', './src/js/umd']
     };
 
+    if (options.hotComponents && !options.assetsOnly) {
+        entry.smooch.unshift('webpack-hot-middleware/client');
+    }
+
     const fileLimit = options.bundleAll ? 100000 : 1;
 
-    var loaders = {
+
+    const loaders = {
         'jsx': options.hotComponents ? ['react-hot-loader', 'babel-loader'] : 'babel-loader',
         'js': {
             loader: 'babel-loader',
@@ -36,24 +41,24 @@ module.exports = function(options) {
         'png|jpg|jpeg|gif|svg': `url-loader?limit=${fileLimit}`,
         'mp3': `url-loader?limit=${fileLimit}`
     };
-    var cssLoader = options.minimize ? 'css-loader?insertAt=top' : 'css-loader?insertAt=top&localIdentName=[path][name]---[local]---[hash:base64:5]';
-    var stylesheetLoaders = {
+    const cssLoader = options.minimize ? 'css-loader?insertAt=top' : 'css-loader?insertAt=top&localIdentName=[path][name]---[local]---[hash:base64:5]';
+    const stylesheetLoaders = {
         'css': cssLoader,
         'less': [cssLoader, 'less-loader']
     };
-    var additionalLoaders = [];
+    const additionalLoaders = [];
 
-    var alias = {};
+    const alias = {};
 
-    var externals = [];
-    var modulesDirectories = ['node_modules'];
-    var extensions = ['', '.web.js', '.js', '.jsx'];
-    var root = path.join(__dirname, 'src');
-    var publicPath = options.devServer ?
+    const externals = [];
+    const modulesDirectories = ['node_modules'];
+    const extensions = ['', '.web.js', '.js', '.jsx'];
+    const root = path.join(__dirname, 'src');
+    const publicPath = options.devServer ?
         '/_assets/' :
         'https://cdn.smooch.io/';
 
-    var output = {
+    const output = {
         path: options.outputPath || path.join(__dirname, 'dist'),
         publicPath: publicPath,
         filename: '[name].js' + (options.longTermCaching ? '?[chunkhash]' : ''),
@@ -64,11 +69,11 @@ module.exports = function(options) {
         pathinfo: options.debug
     };
 
-    var excludeFromStats = [
+    const excludeFromStats = [
         /node_modules[\\\/]/
     ];
 
-    var plugins = [
+    const plugins = [
         new webpack.PrefetchPlugin('react'),
         new webpack.PrefetchPlugin('react/lib/ReactComponentBrowserEnvironment')
     ];
@@ -82,7 +87,7 @@ module.exports = function(options) {
     }
 
     Object.keys(stylesheetLoaders).forEach(function(ext) {
-        var stylesheetLoader = stylesheetLoaders[ext];
+        let stylesheetLoader = stylesheetLoaders[ext];
         if (Array.isArray(stylesheetLoader)) {
             stylesheetLoader = stylesheetLoader.join('!');
         }
@@ -132,6 +137,14 @@ module.exports = function(options) {
                     NODE_ENV: JSON.stringify('development')
                 }
             })
+        );
+    }
+
+    if (options.hotComponents) {
+        plugins.push(
+            new webpack.optimize.OccurrenceOrderPlugin(),
+            new webpack.HotModuleReplacementPlugin(),
+            new webpack.NoErrorsPlugin()
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
     "build:staging": "webpack --config webpack-staging.config.js --progress --profile --colors",
     "build:assets": "webpack --config webpack-assets.config.js --progress --profile --colors",
     "build:npm": "rm -rf lib/ && npm run babelify && npm run build:assets && rm -f lib/constants/*.mp3 && rm -f lib/constants/*.png",
-    "dev-server": "webpack-dev-server --config webpack-dev-server.config.js --colors --port 2992 --inline  --no-info",
     "start": "node dev-server/server-production",
     "lint": "eslint . --ext=js --ext=jsx",
     "babelify": "babel -d lib/ src/js/",
-    "dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development",
-    "webpack": "webpack-dev-server --config webpack-hot-dev-server.config.js --hot --colors --port 2992 --inline --no-info"
+    "dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development"
   },
   "main": "lib/main.js",
   "homepage": "https://smooch.io",
@@ -141,7 +139,9 @@
     "url-loader": "0.5.7",
     "webpack": "1.12.9",
     "webpack-cli": "1.0.0",
-    "webpack-dev-server": "1.14.0"
+    "webpack-dev-middleware": "1.9.0",
+    "webpack-dev-server": "1.14.0",
+    "webpack-hot-middleware": "2.15.0"
   },
   "peerDependencies": {
     "babel-polyfill": ">=6.9.0 <7.0",

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -1,5 +1,6 @@
 module.exports = require('./make-webpack-config')({
     devServer: true,
+    hotComponents: true,
     devtool: 'inline-source-map',
     debug: true
 });

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -1,6 +1,0 @@
-module.exports = require('./make-webpack-config')({
-    devServer: true,
-    hotComponents: true,
-    devtool: 'inline-source-map',
-    debug: true
-});


### PR DESCRIPTION
At last, no need to run `npm run webpack` in a separated console anymore!

With these changes, all you need to run is `npm run dev` and that's it. Webpack is now run as a middleware in the express server.