### PR TITLE
Cancel pending updates when a user logs in or out

### DIFF
--- a/smooch-js.sublime-project
+++ b/smooch-js.sublime-project
@@ -1,7 +1,7 @@
 {
     "folders": [{
         "path": ".",
-        "folder_exclude_patterns": ["node_modules", "tmp", "dist", "bower_components", "coverage", "vendor", "temp"]
+        "folder_exclude_patterns": ["node_modules", "tmp", "dist", "bower_components", "coverage", "vendor", "temp", "lib"]
     }],
     "settings": {
         "tab_size": 4,

--- a/src/js/services/user.js
+++ b/src/js/services/user.js
@@ -4,7 +4,7 @@ import { setUser } from '../actions/user-actions';
 import { core } from './core';
 import { handleConversationUpdated } from './conversation';
 
-const waitDelay = 10000; // ms
+const waitDelay = 5000; // ms
 let pendingUserProps = {};
 let pendingUpdatePromise;
 let pendingResolve;


### PR DESCRIPTION
If user prop updates were queued when a user logged in or out, the
`setTimeout` was not being cleared, and would run after the new user
was logged in. This changes the logic to cancel pending timers when
`immediateUpdate` is called, as is the case on login/logout.

This is an attempt to address #396 and #445