### PR TITLE
Fix file picker on Microsoft Edge

### DIFF
--- a/src/js/components/image-upload.jsx
+++ b/src/js/components/image-upload.jsx
@@ -52,24 +52,36 @@ export class ImageUploadComponent extends Component {
     }
 
     render() {
-        const style = {};
+        const styles = {
+            form: {
+                flex: 0
+            },
+            icon: {}
+        };
 
         if (this.props.color && this.state.imageButtonHovered) {
-            style.color = `#${this.props.color}`;
+            styles.icon.color = `#${this.props.color}`;
         }
-        return <label className='btn btn-sk-link image-upload'
-                      onMouseOver={ this.onMouseOver }
-                      onMouseOut={ this.onMouseOut }
-                      style={ style }>
-                   <form ref={ (c) => this._formNode = findDOMNode(c) }
-                         onSubmit={ preventDefault }>
-                       <input type='file'
-                              accept='image/*'
-                              onChange={ this.onImageChange }
-                              ref={ (c) => this._fileInputNode = findDOMNode(c) } />
-                   </form>
-                   <i className='fa fa-camera'></i>
-               </label>;
+        return <form ref={ (c) => this._formNode = findDOMNode(c) }
+                     onSubmit={ preventDefault }
+                     style={ styles.form }>
+                   <label className='btn btn-sk-link image-upload'
+                          for='sk-img-upload'
+                          onMouseOver={ this.onMouseOver }
+                          onMouseOut={ this.onMouseOut }
+                          style={ styles.icon }
+                          onClick={ (e) => {
+                                        e.preventDefault();
+                                        this._fileInputNode.click();
+                                    } }>
+                       <i className='fa fa-camera'></i>
+                   </label>
+                   <input type='file'
+                          id='sk-img-upload'
+                          accept='image/*'
+                          onChange={ this.onImageChange }
+                          ref={ (c) => this._fileInputNode = findDOMNode(c) } />
+               </form>;
     }
 }
 

--- a/src/stylesheets/footer.less
+++ b/src/stylesheets/footer.less
@@ -23,11 +23,11 @@
         &:hover {
             color: #00aeff;
         }
+    }
 
-        input[type="file"] {
-            position: fixed;
-            top: -1000px;
-        }
+    input[type="file"] {
+        position: fixed;
+        top: -1000px;
     }
 
     form {


### PR DESCRIPTION
There is a bug on edge that causes the filer picker dialog to
constantly re-open itself when a file input is nested inside a label.
This change works around that issue, placing the input beside the
label in the DOM, as well as adds `for` and `id` attributes to those
elements.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8282613/