### PR TITLE
Track current location in store and update button icon with location

### DIFF
--- a/src/js/actions/browser-actions.js
+++ b/src/js/actions/browser-actions.js
@@ -1,8 +1,16 @@
 export const SET_HAS_FOCUS = 'SET_HAS_FOCUS';
+export const SET_CURRENT_LOCATION = 'SET_CURRENT_LOCATION';
 
 export function hasFocus(value) {
     return {
         type: SET_HAS_FOCUS,
         hasFocus: value
+    };
+}
+
+export function setCurrentLocation(location) {
+    return {
+        type: SET_CURRENT_LOCATION,
+        location
     };
 }

--- a/src/js/components/default-button-icon.jsx
+++ b/src/js/components/default-button-icon.jsx
@@ -1,0 +1,51 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { SK_DARK_CONTRAST } from '../constants/styles';
+
+export class DefaultButtonIconComponent extends Component {
+    static propTypes = {
+        isBrandColorDark: PropTypes.bool.isRequired,
+        location: PropTypes.object.isRequired
+    };
+
+    render() {
+        const {isBrandColorDark, location} = this.props;
+
+        const {protocol, host, pathname, search} = location;
+
+        return <svg version='1.0'
+                    x='0px'
+                    y='0px'
+                    viewBox='0 0 100 100'
+                    className='default-icon'
+                    style={ {    enableBackground: 'new 0 0 100 100',    overflow: 'visible',    shapeRendering: 'geometricPrecision'} }>
+                   <filter id='33c9df204aeec9aa096f1fd360bd4160'>
+                       <feGaussianBlur stdDeviation='0,4'
+                                       in='SourceAlpha' />
+                       <feOffset dx='0'
+                                 dy='4'
+                                 result='offsetblur' />
+                       <feComponentTransfer>
+                           <feFuncA type='linear'
+                                    slope='0.4' />
+                       </feComponentTransfer>
+                       <feComposite operator='in'
+                                    in2='offsetblur' />
+                       <feMerge>
+                           <feMergeNode/>
+                           <feMergeNode in='SourceGraphic' />
+                       </feMerge>
+                   </filter>
+                   <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
+                         filter={ `url(${protocol}//${host}${pathname}${search}#33c9df204aeec9aa096f1fd360bd4160)` }
+                         d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
+               </svg>;
+    }
+}
+
+export const DefaultButtonIcon = connect(({browser: {currentLocation}}) => {
+    return {
+        location: currentLocation
+    };
+})(DefaultButtonIconComponent);

--- a/src/js/components/messenger-button.jsx
+++ b/src/js/components/messenger-button.jsx
@@ -3,44 +3,7 @@ import { connect } from 'react-redux';
 import bindAll from 'lodash.bindall';
 
 import { openWidget } from '../services/app';
-import { SK_DARK_CONTRAST } from '../constants/styles';
-
-export class DefaultButtonIcon extends Component {
-
-    render() {
-        const {isBrandColorDark} = this.props;
-
-        const {protocol, host, pathname, search} = window.location;
-
-        return <svg version='1.0'
-                    x='0px'
-                    y='0px'
-                    viewBox='0 0 100 100'
-                    className='default-icon'
-                    style={ {    enableBackground: 'new 0 0 100 100',    overflow: 'visible',    shapeRendering: 'geometricPrecision'} }>
-                   <filter id='dropShadow'>
-                       <feGaussianBlur stdDeviation='0,4'
-                                       in='SourceAlpha' />
-                       <feOffset dx='0'
-                                 dy='4'
-                                 result='offsetblur' />
-                       <feComponentTransfer>
-                           <feFuncA type='linear'
-                                    slope='0.4' />
-                       </feComponentTransfer>
-                       <feComposite operator='in'
-                                    in2='offsetblur' />
-                       <feMerge>
-                           <feMergeNode/>
-                           <feMergeNode in='SourceGraphic' />
-                       </feMerge>
-                   </filter>
-                   <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
-                         filter={ `url(${protocol}//${host}${pathname}${search}#dropShadow)` }
-                         d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
-               </svg>;
-    }
-}
+import { DefaultButtonIcon } from './default-button-icon';
 
 export class MessengerButtonComponent extends Component {
 
@@ -82,8 +45,7 @@ export class MessengerButtonComponent extends Component {
                                src={ buttonIconUrl } />
                       </div>;
         } else {
-            content = <DefaultButtonIcon isBrandColorDark={ isBrandColorDark }
-                                         brandColor={ brandColor } />;
+            content = <DefaultButtonIcon isBrandColorDark={ isBrandColorDark } />;
         }
 
         let unreadBadge;

--- a/src/js/reducers/browser-reducer.js
+++ b/src/js/reducers/browser-reducer.js
@@ -1,8 +1,9 @@
-import { SET_HAS_FOCUS } from '../actions/browser-actions';
+import { SET_HAS_FOCUS, SET_CURRENT_LOCATION } from '../actions/browser-actions';
 import { RESET } from '../actions/common-actions';
 
 const INITIAL_STATE = {
-    hasFocus: false
+    hasFocus: false,
+    currentLocation: document.location
 };
 
 export function BrowserReducer(state = INITIAL_STATE, action) {
@@ -10,9 +11,17 @@ export function BrowserReducer(state = INITIAL_STATE, action) {
         case RESET:
             return Object.assign({}, INITIAL_STATE);
         case SET_HAS_FOCUS:
-            return Object.assign({}, state, {
+            return {
+                ...state,
                 hasFocus: action.hasFocus
-            });
+            };
+        case SET_CURRENT_LOCATION:
+            return {
+                ...state,
+                currentLocation: {
+                    ...action.location
+                }
+            };
         default:
             return state;
     }

--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -9,6 +9,7 @@ import { setAuth, resetAuth } from './actions/auth-actions';
 import * as userActions from './actions/user-actions';
 import { setStripeInfo, setApp } from './actions/app-actions';
 import { updateText } from './actions/ui-actions';
+import { setCurrentLocation } from './actions/browser-actions';
 import { resetConversation } from './actions/conversation-actions';
 import { resetIntegrations } from './actions/integrations-actions';
 import * as AppStateActions from './actions/app-state-actions';
@@ -230,8 +231,14 @@ export class Smooch {
             actions.push(userActions.setUser(loginResponse.appUser));
             actions.push(setApp(loginResponse.app));
 
+            actions.push(setCurrentLocation(document.location));
             monitorUrlChanges(() => {
-                store.dispatch(updateNowViewing(getDeviceId()));
+                const actions = [
+                    setCurrentLocation(document.location),
+                    updateNowViewing(getDeviceId())
+                ];
+
+                store.dispatch(batchActions(actions));
             });
 
             if (hasChannels(loginResponse.app.settings.web)) {

--- a/test/specs/components/messenger-button.spec.js
+++ b/test/specs/components/messenger-button.spec.js
@@ -2,7 +2,8 @@ import sinon from 'sinon';
 import TestUtils from 'react-addons-test-utils';
 import deepAssign from 'deep-assign';
 
-import { MessengerButton, DefaultButtonIcon } from '../../../src/js/components/messenger-button';
+import { MessengerButton } from '../../../src/js/components/messenger-button';
+import { DefaultButtonIconComponent } from '../../../src/js/components/default-button-icon';
 
 import { mockComponent, wrapComponentWithStore } from '../../utils/react';
 import { createMockedStore } from '../../utils/redux';
@@ -14,12 +15,16 @@ function getStoreState(state = {}) {
         app: {
             settings: {
                 web: {
-                    channels: {}
+                    channels: {},
+                    isBrandColorDark: true
                 }
             }
         },
         conversation: {
             unreadCount: 0
+        },
+        browser: {
+            currentLocation: {}
         }
     };
 
@@ -29,7 +34,7 @@ function getStoreState(state = {}) {
 describe('Messenger Button Component', () => {
     let mockedStore;
     beforeEach(() => {
-        mockComponent(sandbox, DefaultButtonIcon, 'div', {
+        mockComponent(sandbox, DefaultButtonIconComponent, 'div', {
             className: 'mockedDefaultButtonIcon'
         });
     });


### PR DESCRIPTION
Some people reported problems where the icon in the messenger button wasn't showing up on Firefox once again. Last time we fixed that by using the full url for the drop shadow filter url but we we're listening to url changes. This PR now tracks location changes and store the new location in the store so any component can be notified and updated when it changes.

I also changed the filter `id` for some random value to prevent clashing with anything with the id `dropShadow` in the host page.