### PR TITLE
unreadCount event

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -100,10 +100,10 @@ function onStoreChange({messages, unreadCount}) {
                     initialStoreChange = false;
                 } else {
                     handleNotificationSound();
-                    observable.trigger('unreadCount', unreadCount);
                 }
             });
         }
+        observable.trigger('unreadCount', unreadCount);
     }
 }
 


### PR DESCRIPTION
The event should be triggered outside the `if (unreadCount > 0) { }`. Otherwise it defeats most of its purpose.