### PR TITLE
Use onScroll instead of onWheel

### DIFF
--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -45,18 +45,11 @@ export class WidgetComponent extends Component {
 
     onClick = () => {
         resetUnreadCount();
-
     };
 
     handleResize = () => {
         this.props.dispatch(disableAnimation());
     };
-
-    onScroll = debounce(() => {
-        resetUnreadCount();
-    }, 250, {
-        leading: true
-    });
 
     componentDidMount = () => {
         window.addEventListener('resize', this.handleResize);
@@ -122,8 +115,7 @@ export class WidgetComponent extends Component {
                    <div id='sk-container'
                         className={ classNames.join(' ') }
                         onTouchStart={ this.onTouchStart }
-                        onClick={ this.onClick }
-                        onScroll={ this.onScroll }>
+                        onClick={ this.onClick }>
                        <MessageIndicator />
                        <div id='sk-wrapper'
                             className={ wrapperClassNames.join(' ') }>

--- a/src/js/components/widget.jsx
+++ b/src/js/components/widget.jsx
@@ -52,7 +52,7 @@ export class WidgetComponent extends Component {
         this.props.dispatch(disableAnimation());
     };
 
-    onWheel = debounce(() => {
+    onScroll = debounce(() => {
         resetUnreadCount();
     }, 250, {
         leading: true
@@ -123,7 +123,7 @@ export class WidgetComponent extends Component {
                         className={ classNames.join(' ') }
                         onTouchStart={ this.onTouchStart }
                         onClick={ this.onClick }
-                        onWheel={ this.onWheel }>
+                        onScroll={ this.onScroll }>
                        <MessageIndicator />
                        <div id='sk-wrapper'
                             className={ wrapperClassNames.join(' ') }>


### PR DESCRIPTION
Using onWheel was causing significant performance issue because whenever onWheel is used, React binds an event on the page directly and not just the target. We were using onWheel to reset the unread count but only when the user is scroll with their mousewheel. I switch it to use onScroll instead. The downside is that the event is trigger also when the conversation is scrolled down with a new message, but the operation is a noop when unread count is 0.
