### PR TITLE
Dispatch action to store when loading more

### DIFF
--- a/release_notes/v3.13.3.md
+++ b/release_notes/v3.13.3.md
@@ -1,0 +1,3 @@
+# What's new?
+
+- Fix a problem where scrolling up the conversation wouldn't fetch the next page of messages.

--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -98,7 +98,7 @@ export class ConversationComponent extends Component {
 
         // Timeout is needed because we need to compute sizes of HTML elements and thus need to make sure everything has rendered
         setTimeout(() => {
-            fetchMoreMessages();
+            dispatch(fetchMoreMessages());
         }, 400);
     };
 


### PR DESCRIPTION
This one was forgotten when I did the great refactor of 2017. The action was never dispatched to the store. The http call was never made.

This fixes it.