### PR TITLE
Throttle getMessages calls

### DIFF
--- a/src/js/services/conversation.js
+++ b/src/js/services/conversation.js
@@ -9,6 +9,7 @@ import { core } from './core';
 import { immediateUpdate } from './user';
 import { disconnectClient, subscribeConversation, subscribeUser, subscribeConversationActivity } from './faye';
 import { observable } from '../utils/events';
+import { Throttle } from '../utils/throttle';
 import { resizeImage, getBlobFromDataUrl, isFileTypeSupported } from '../utils/media';
 import { getDeviceId } from '../utils/device';
 import { hasLinkableChannels, getLinkableChannels, isChannelLinked } from '../utils/user';
@@ -16,6 +17,8 @@ import { getWindowLocation } from '../utils/dom';
 import { CONNECT_NOTIFICATION_DELAY_IN_SECONDS } from '../constants/notifications';
 import { SEND_STATUS, LOCATION_ERRORS } from '../constants/message';
 import { getUserId } from './user';
+
+const getMessagesThrottle = new Throttle();
 
 const postSendMessage = (message) => {
     return (dispatch, getState) => {
@@ -248,7 +251,7 @@ export function uploadImage(file) {
 }
 
 export function getMessages() {
-    return (dispatch, getState) => {
+    return (dispatch, getState) => getMessagesThrottle.exec(() => {
         return core(getState()).appUsers.getMessages(getUserId(getState())).then((response) => {
             dispatch(batchActions([
                 setConversation({
@@ -259,7 +262,7 @@ export function getMessages() {
             ]));
             return response;
         });
-    };
+    });
 }
 
 export function connectFayeConversation() {

--- a/src/js/utils/throttle.js
+++ b/src/js/utils/throttle.js
@@ -1,0 +1,32 @@
+
+/**
+ * Throttle for functions that return a promise. If additional calls are made
+ * while the throttle is on, the original promise will be returned.
+ *
+ * Usage:
+ *
+ * const func = () => Promise.resolve('foo')
+ *
+ * const throttle = new Throttle();
+ * const throttledFunc = () => throttle.exec(() => func());
+ * throttledFunc().then((foo) => {})
+ */
+export class Throttle {
+    constructor(waitMs = 5000) {
+        this.waitMs = waitMs;
+        this.throttled;
+        this.promise;
+    }
+
+    exec(func) {
+        if (this.throttled) {
+            return this.promise;
+        }
+
+        this.throttled = true;
+        setTimeout(() => this.throttled = false, this.waitMs);
+
+        this.promise = func();
+        return this.promise;
+    }
+};

--- a/test/specs/services/conversation.spec.js
+++ b/test/specs/services/conversation.spec.js
@@ -16,6 +16,7 @@ import * as appStateActions from '../../../src/js/actions/app-state-actions';
 import * as conversationActions from '../../../src/js/actions/conversation-actions';
 import * as userActions from '../../../src/js/actions/user-actions';
 import * as fayeActions from '../../../src/js/actions/faye-actions';
+import { Throttle } from '../../../src/js/utils/throttle';
 
 import { SEND_STATUS, LOCATION_ERRORS } from '../../../src/js/constants/message';
 
@@ -77,6 +78,9 @@ describe('Conversation service', () => {
     });
 
     beforeEach(() => {
+        // Disable throttling for unit tests
+        sandbox.stub(Throttle.prototype, 'exec', (func) => func());
+
         coreMock = createMock(sandbox);
         coreMock.appUsers.getMessages.resolves({
             conversation: {

--- a/test/specs/services/integrations.spec.js
+++ b/test/specs/services/integrations.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { createMock } from '../../mocks/core';
 import { createMockedStore } from '../../utils/redux';
 
+import { Throttle } from '../../../src/js/utils/throttle';
 import * as coreService from '../../../src/js/services/core';
 import * as integrationsService from '../../../src/js/services/integrations';
 import * as utilsFaye from '../../../src/js/services/faye';
@@ -15,6 +16,9 @@ describe('Integrations service', () => {
     let pendingAppUser;
 
     beforeEach(() => {
+        // Disable throttling for unit tests
+        sandbox.stub(Throttle.prototype, 'exec', (func) => func());
+
         pendingAppUser = {
             appuser: {
                 _id: '1',

--- a/test/specs/utils/throttle.spec.js
+++ b/test/specs/utils/throttle.spec.js
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+
+import { Throttle } from '../../../src/js/utils/throttle';
+
+describe('Throttle', () => {
+    let throttledFunc;
+    let counter;
+
+    beforeEach(() => {
+        counter = 0;
+        const waitTimeMs = 1;
+        const throttle = new Throttle(waitTimeMs);
+
+        throttledFunc = () => throttle.exec(() => {
+            return new Promise((resolve) => {
+                counter++;
+                setTimeout(() => resolve(counter), 1);
+            });
+        });
+    });
+
+    it('should resolve with wrapped promise', () => {
+        throttledFunc().then((result) => {
+            result.should.eql(1);
+        });
+    });
+
+    it('should return original promise when throttled', () => {
+        const firstCall = throttledFunc()
+        const secondCall = throttledFunc();
+
+        return Promise.all([firstCall, secondCall])
+            .then(([firstResult, secondResult]) => {
+                firstResult.should.eql(1);
+                secondResult.should.eql(1);
+            });
+    });
+
+    it('should make a fresh call after the throttle expires', () => {
+        throttledFunc()
+
+        let secondCall;
+        const waitTwoMs = new Promise((resolve) => {
+            setTimeout(() => {
+                 secondCall = throttledFunc();
+                resolve();
+            }, 2);
+        });
+
+        return waitTwoMs
+            .then(() => secondCall)
+            .then((thirdResult) => {
+                thirdResult.should.eql(2);
+            });
+    });
+});


### PR DESCRIPTION
I have the default throttle interval set to 5 seconds, open to feedback on that.

Note that this throttling does not apply to get scrolling pagination, and each user gets their own throttle, so if you log in as a different user you won't have to wait 5 seconds to see your conversation.