### PR TITLE
Force reply icons to be squared

### DIFF
--- a/src/stylesheets/reply-actions.less
+++ b/src/stylesheets/reply-actions.less
@@ -29,13 +29,10 @@
             white-space: nowrap;
 
             .sk-reply-action-icon, .sk-location-icon {
+                width: 20px;
                 height: 20px;
                 vertical-align: bottom;
                 margin-right: 5px;
-            }
-
-            .sk-location-icon {
-                width: 20px;
             }
         }
     }


### PR DESCRIPTION
Icons were allowed to be of variable width which caused the scrolling behavior to work in a weird way sometimes. If a wide icon was to be displayed, the computation for the scroll would be wrong because it would happen before the icon is loaded and then the action buttons would wrap under the scroll point.

This fixes it by forcing a fixed width on icons. iOS and Android are already working like that.