### PR TITLE
Prevent destroy if it was not initialized first

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -76,6 +76,7 @@ observable.on('message:received', (message) => {
 
 let lastTriggeredMessageTimestamp = 0;
 let initialStoreChange = true;
+let isInitialized = false;
 let unsubscribeFromStore;
 
 function handleNotificationSound() {
@@ -119,6 +120,8 @@ export class Smooch {
     }
 
     init(props) {
+        isInitialized = true;
+
         props = {
             imageUploadEnabled: true,
             soundNotificationEnabled: true,
@@ -321,6 +324,11 @@ export class Smooch {
     }
 
     destroy() {
+        if (!isInitialized) {
+            return;
+        }
+        isInitialized = false;
+
         if (!this.appToken) {
             console.warn('Smooch.destroy was called before Smooch.init was called properly.');
         }

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -419,19 +419,51 @@ describe('Smooch', () => {
         beforeEach(() => {
             mockedStore = mockAppStore(sandbox, defaultState);
             disconnectFayeStub = sandbox.stub(conversationService, 'disconnectFaye');
+            loginStub = sandbox.stub(smooch, 'login').resolves();
         });
 
-        it('should reset store state and remove the container', () => {
-            smooch.destroy();
-            commonActions.reset.should.have.been.calledOnce;
-            document.body.removeChild.should.have.been.calledOnce;
+        describe('with init first', () => {
+            beforeEach((done) => {
+                smooch.init().then(done);
+            });
+
+            it('should reset store state and remove the container', () => {
+                smooch.destroy();
+                commonActions.reset.should.have.been.calledOnce;
+                document.body.removeChild.should.have.been.calledOnce;
+            });
+
+            it('should not remove the container from body if it is undefined', () => {
+                delete smooch._container;
+                smooch.destroy();
+                commonActions.reset.should.have.been.calledOnce;
+                document.body.removeChild.should.not.have.been.calledOnce;
+            });
         });
 
-        it('should not remove the container from body if it is undefined', () => {
-            delete smooch._container;
-            smooch.destroy();
-            commonActions.reset.should.have.been.calledOnce;
-            document.body.removeChild.should.not.have.been.calledOnce;
+        describe('without init first', () => {
+            it('should do nothing', () => {
+                smooch.destroy();
+                commonActions.reset.should.not.have.been.calledOnce;
+                document.body.removeChild.should.not.have.been.calledOnce;
+            });
+        });
+
+        describe('with init first then destroy twice', () => {
+            beforeEach((done) => {
+                smooch.init().then(done);
+            });
+
+            it('should do nothing on the second call', () => {
+                smooch.destroy();
+                commonActions.reset.should.have.been.calledOnce;
+                document.body.removeChild.should.have.been.calledOnce;
+
+                smooch.destroy();
+                commonActions.reset.should.not.have.been.calledTwice;
+                document.body.removeChild.should.not.have.been.calledTwice;
+            });
+
         });
     });
 


### PR DESCRIPTION
Should fix #489 and #490.

Destroying had bad side effects when the Web Messenger wasn't initialized first.