### PR TITLE
Remove height of header for content-wrapper

### DIFF
--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -40,24 +40,24 @@
     @import (css) "~react-spinkit/css/three-bounce.css";
 }
 
-.widget-size() {
+.widget-size(@offsetHeight:0) {
     width: @widget-width-md;
-    height: @widget-height-md;
+    height: @widget-height-md + @offsetHeight;
     @media (min-width: @screen-lg-min) and (min-height: @screen-md-ht-min) {
         width: @widget-width-lg;
-        height: @widget-height-lg;
+        height: @widget-height-lg + @offsetHeight;
     }
     @media (min-width: @screen-sm-min) and (min-height: @screen-sm-ht-min) and (max-height: @screen-sm-ht-max) {
         width: @widget-width-md;
-        height: @widget-height-md;
+        height: @widget-height-md + @offsetHeight;
     }
     @media (min-width: @screen-sm-min) and (max-height: @screen-xs-ht-max) {
         width: @widget-width-sm;
-        height: @widget-height-sm;
+        height: @widget-height-sm + @offsetHeight;
     }
     @media (max-width: @screen-sm-min) {
         width: @widget-width-xs;
-        height: @widget-height-xs;
+        height: @widget-height-xs + @offsetHeight;
     }
 }
 
@@ -110,7 +110,7 @@
 
         .content-wrapper {
             .scrollbar-mixin();
-            .widget-size();
+            .widget-size(-@header-extra-height);
             overflow-y: auto;
         }
     }


### PR DESCRIPTION
Settings was scrolling but not enough because we didn't take in account the header height when computing the content wrapper size.

I added a parameter to the `widget-size` function so we can have all the responsive rules and add some adjustments for the height. `widget-size` is also used for the outer container.