### PR TITLE
Remove useless warning on destroy

### DIFF
--- a/src/js/smooch.jsx
+++ b/src/js/smooch.jsx
@@ -329,10 +329,6 @@ export class Smooch {
         }
         isInitialized = false;
 
-        if (!this.appToken) {
-            console.warn('Smooch.destroy was called before Smooch.init was called properly.');
-        }
-
         stopMonitoringBrowserState();
 
         if (process.env.NODE_ENV !== 'test' && this._container) {


### PR DESCRIPTION
This warning makes no sense now that we have a proper check and it would also warn when using jwt authentication.

It must be a old remnant of a previous era.