### PR TITLE
Change FontAwesome font name to avoid clashing

### DIFF
--- a/src/stylesheets/font-awesome/core.less
+++ b/src/stylesheets/font-awesome/core.less
@@ -3,7 +3,7 @@
 
 .@{fa-css-prefix} {
   display: inline-block;
-  font: normal normal normal @fa-font-size-base/@fa-line-height-base FontAwesome; // shortening font declaration
+  font: normal normal normal @fa-font-size-base/@fa-line-height-base FontAwesome-Smooch; // shortening font declaration
   font-size: inherit; // can't have font-size inherit on line above, so need to override
   text-rendering: auto; // optimizelegibility throws things off #1094
   -webkit-font-smoothing: antialiased;

--- a/src/stylesheets/font-awesome/mixins.less
+++ b/src/stylesheets/font-awesome/mixins.less
@@ -3,7 +3,7 @@
 
 .fa-icon() {
   display: inline-block;
-  font: normal normal normal @fa-font-size-base/@fa-line-height-base FontAwesome; // shortening font declaration
+  font: normal normal normal @fa-font-size-base/@fa-line-height-base FontAwesome-Smooch; // shortening font declaration
   font-size: inherit; // can't have font-size inherit on line above, so need to override
   text-rendering: auto; // optimizelegibility throws things off #1094
   -webkit-font-smoothing: antialiased;

--- a/src/stylesheets/font-awesome/path.less
+++ b/src/stylesheets/font-awesome/path.less
@@ -2,7 +2,7 @@
  * -------------------------- */
 
 @font-face {
-  font-family: 'FontAwesome';
+  font-family: 'FontAwesome-Smooch';
   src: url('@{fa-font-path}/fontawesome-webfont.eot?v=@{fa-version}');
   src: url('@{fa-font-path}/fontawesome-webfont.eot?#iefix&v=@{fa-version}') format('embedded-opentype'),
     url('@{fa-font-path}/fontawesome-webfont.woff2?v=@{fa-version}') format('woff2'),


### PR DESCRIPTION
Since we're loading a specific version of Font Awesome without changing the font name, we are replacing the `FontAwesome` typeface in any site that already uses it. In case like #521, we are probably using different versions of FA and ours has less icons than theirs. When ours loads, it makes the missing icons disappear from the page.

This should prevent any clash in font names. Really not sure why we didn't do that earlier, but here it is.