### PR TITLE
Call unthrottled getMessage action when connecting faye

### DIFF
--- a/src/js/components/conversation.jsx
+++ b/src/js/components/conversation.jsx
@@ -26,7 +26,7 @@ export class ConversationComponent extends Component {
         embedded: PropTypes.bool.isRequired,
         shouldScrollToBottom: PropTypes.bool.isRequired,
         isFetchingMoreMessages: PropTypes.bool.isRequired,
-        hasMoreMessages: PropTypes.bool.isRequired,
+        hasMoreMessages: PropTypes.bool,
         introHeight: PropTypes.number,
         connectNotificationTimestamp: PropTypes.number,
         errorNotificationMessage: PropTypes.string,

--- a/src/js/services/conversation.js
+++ b/src/js/services/conversation.js
@@ -20,14 +20,14 @@ import { getUserId } from './user';
 
 
 // Throttle requests per appUser
-const throttleMap = {}
+const throttleMap = {};
 const throttlePerUser = (userId) => {
     if (!throttleMap[userId]) {
         throttleMap[userId] = new Throttle();
     }
 
     return throttleMap[userId];
-}
+};
 
 const postSendMessage = (message) => {
     return (dispatch, getState) => {
@@ -259,24 +259,26 @@ export function uploadImage(file) {
     };
 }
 
-function _getMessages(dispatch, getState) {
-    const userId = getUserId(getState());
-    return core(getState()).appUsers.getMessages(userId).then((response) => {
-        dispatch(batchActions([
-            setConversation({
-                ...response.conversation,
-                hasMoreMessages: !!response.previous
-            }),
-            setMessages(response.messages)
-        ]));
-        return response;
-    });
+export function _getMessages() {
+    return (dispatch, getState) => {
+        const userId = getUserId(getState());
+        return core(getState()).appUsers.getMessages(userId).then((response) => {
+            dispatch(batchActions([
+                setConversation({
+                    ...response.conversation,
+                    hasMoreMessages: !!response.previous
+                }),
+                setMessages(response.messages)
+            ]));
+            return response;
+        });
+    };
 }
 
 export function getMessages() {
     return (dispatch, getState) => {
         const userId = getUserId(getState());
-        return throttlePerUser(userId).exec(() => _getMessages(dispatch, getState));
+        return throttlePerUser(userId).exec(() => dispatch(_getMessages()));
     };
 }
 

--- a/src/js/services/faye.js
+++ b/src/js/services/faye.js
@@ -5,7 +5,7 @@ import { batchActions } from 'redux-batched-actions';
 import { setUser } from '../actions/user-actions';
 import { setFayeConversationSubscription, setFayeUserSubscription, setFayeConversationActivitySubscription } from '../actions/faye-actions';
 import { addMessage, incrementUnreadCount, resetUnreadCount } from '../actions/conversation-actions';
-import { getMessages, disconnectFaye, handleConversationUpdated } from './conversation';
+import { _getMessages, disconnectFaye, handleConversationUpdated } from './conversation';
 import { showSettings, hideChannelPage, hideConnectNotification, showTypingIndicator, hideTypingIndicator } from './app';
 import { getDeviceId } from '../utils/device';
 import { ANIMATION_TIMINGS } from '../constants/styles';
@@ -44,7 +44,7 @@ export function getClient() {
                 const {user} = getState();
 
                 if (user.conversationStarted) {
-                    dispatch(getMessages());
+                    dispatch(_getMessages());
                 }
             });
         }
@@ -135,7 +135,7 @@ export function updateUser(currentAppUser, nextAppUser) {
             if (currentAppUser.conversationStarted) {
                 // if the conversation is already started,
                 // fetch the conversation for merged messages
-                return dispatch(getMessages());
+                return dispatch(() => _getMessages());
             } else if (nextAppUser.conversationStarted) {
                 // if the conversation wasn't already started,
                 // `handleConversationUpdated` will connect faye and fetch it

--- a/test/specs/components/reply-actions.spec.js
+++ b/test/specs/components/reply-actions.spec.js
@@ -48,7 +48,13 @@ describe('ReplyActions Component', () => {
         sandbox.stub(conversationService, 'sendMessage');
         sandbox.stub(conversationService, 'sendLocation');
         geolocation = navigator.geolocation;
-        navigator.geolocation = true;
+        try {
+            // can't reassign this prop in Chrome
+            navigator.geolocation = true;
+        }
+        catch (e) {
+            console.log(e);
+        }
 
         component = wrapComponentWithStore(ReplyActions, {
             choices: CHOICES
@@ -56,8 +62,14 @@ describe('ReplyActions Component', () => {
     });
 
     afterEach(() => {
-        navigator.geolocation = geolocation;
         sandbox.restore();
+        try {
+            // can't reassign this prop in Chrome
+            navigator.geolocation = geolocation;
+        }
+        catch (e) {
+            console.log(e);
+        }
     });
 
     it('should render choices', () => {

--- a/test/specs/services/faye.spec.js
+++ b/test/specs/services/faye.spec.js
@@ -37,7 +37,7 @@ describe('Faye service', () => {
         mockedStore = createMockedStore(sandbox, getProps());
 
         sandbox.stub(Client.prototype, 'addExtension');
-        sandbox.stub(conversationService, 'getMessages');
+        sandbox.stub(conversationService, '_getMessages');
         sandbox.stub(conversationService, 'disconnectFaye');
         sandbox.stub(conversationService, 'handleConversationUpdated');
         sandbox.stub(appService, 'showSettings');
@@ -66,10 +66,10 @@ describe('Faye service', () => {
             });
         });
         describe('when conversation is started', () => {
-            it('should call getMessages when transport:up event is emitted', () => {
+            it('should call _getMessages when transport:up event is emitted', () => {
                 const client = mockedStore.dispatch(fayeService.getClient());
                 client.subscribe();
-                conversationService.getMessages.should.have.been.calledOnce;
+                conversationService._getMessages.should.have.been.calledOnce;
             });
         });
 
@@ -82,10 +82,10 @@ describe('Faye service', () => {
                 }));
             });
 
-            it('should not call getMessages when transport:up event is emitted', () => {
+            it('should not call _getMessages when transport:up event is emitted', () => {
                 const client = mockedStore.dispatch(fayeService.getClient());
                 client.subscribe();
-                conversationService.getMessages.should.not.have.been.called;
+                conversationService._getMessages.should.not.have.been.called;
             });
         });
     });
@@ -181,7 +181,7 @@ describe('Faye service', () => {
                 it('should fetch conversation', () => {
                     currentAppUser.conversationStarted = true;
                     mockedStore.dispatch(fayeService.updateUser(currentAppUser, nextAppUser));
-                    conversationService.getMessages.should.have.been.calledOnce;
+                    conversationService._getMessages.should.have.been.calledOnce;
                 });
             });
             describe('next appUser started conversation', () => {


### PR DESCRIPTION
This should fix #527. In this example, `getConversation` is called before sending a message which triggers the throttling of `getMessage` which then makes the one on `transport:up` meaningless because it gets throttled.

This makes sure we call the unthrottled version of `getMessages` when faye connects no matter what. It's really the only place where throttling shouldn't happen so we don't miss messages.