### PR TITLE
Send invalidation to Cloudfront instead of MaxCDN

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,25 +16,10 @@ module.exports = function(grunt) {
         awsConfig.key = (process.env.AWS_ACCESS_KEY_ID || awsConfig.key);
         awsConfig.secret = (process.env.AWS_SECRET_ACCESS_KEY || awsConfig.secret);
         awsConfig.bucket = (process.env.SK_JS_S3_BUCKET || awsConfig.bucket);
+        awsConfig.distributionId = (process.env.SK_JS_S3_DISTRIBUTION_ID || awsConfig.distributionId);
+        awsConfig.region = (process.env.SK_JS_S3_REGION || awsConfig.region);
 
         grunt.config.set('aws', awsConfig);
-    });
-
-    grunt.registerTask('maxcdnconfig', function() {
-        var maxCDN;
-        try {
-            maxCDN = grunt.file.readJSON('grunt-maxcdn.json');
-        }
-        catch (e) {
-            maxCDN = {};
-        }
-
-        maxCDN.companyAlias = (process.env.MAXCDN_COMPANY_ALIAS || maxCDN.companyAlias);
-        maxCDN.consumerKey = (process.env.MAXCDN_CONSUMER_KEY || maxCDN.consumerKey);
-        maxCDN.consumerSecret = (process.env.MAXCDN_CONSUMER_SECRET || maxCDN.consumerSecret);
-        maxCDN.zoneId = (process.env.MAXCDN_ZONE_ID || maxCDN.zoneId);
-
-        grunt.config.set('maxcdn.options', maxCDN);
     });
 
     // Project configuration
@@ -73,27 +58,30 @@ module.exports = function(grunt) {
             }
         },
 
+        cloudfront: {
+            options: {
+                region: '<%= aws.region %>',
+                distributionId: '<%= aws.distributionId %>',
+                credentials: {
+                    accessKeyId: '<%= aws.key %>',
+                    secretAccessKey: '<%= aws.secret %>'
+                },
+                listInvalidations: false,
+                listDistributions: false
+            },
+            production: {
+                CallerReference: Date.now().toString(),
+                Paths: {
+                    Quantity: 1,
+                    Items: ['/smooch.min.js']
+                }
+            }
+        },
+
         concurrent: {
             dev: ['exec:hotDevServer', 'exec:devServer'],
             options: {
                 logConcurrentOutput: true
-            }
-        },
-
-        maxcdn: {
-            purgeCache: {
-                options: {
-                    companyAlias: '<%= maxcdn.options.companyAlias %>',
-                    consumerKey: '<%= maxcdn.options.consumerKey %>',
-                    consumerSecret: '<%= maxcdn.options.consumerSecret %>',
-                    zone_id: '<%= maxcdn.options.zoneId %>',
-                    method: 'delete'
-                },
-                files: [
-                    {
-                        dest: '/smooch.min.js'
-                    }
-                ]
             }
         },
 
@@ -258,7 +246,7 @@ module.exports = function(grunt) {
     grunt.registerTask('build', ['clean', 'exec:build', 'exec:buildNpm']);
     grunt.registerTask('dev', ['concurrent:dev']);
 
-    grunt.registerTask('deploy', ['build', 'awsconfig', 'maxcdnconfig', 's3:js', 's3:media', 'maxcdn']);
+    grunt.registerTask('deploy', ['build', 'awsconfig', 's3:js', 's3:media', 'cloudfront:production']);
     grunt.registerTask('default', ['dev']);
 
     grunt.registerTask('publish:prepare', ['versionBump', 'exec:commitFiles', 'exec:createRelease', 'build', 'exec:addDist', 'exec:addLib']);

--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,8 @@ deployment:
       - echo "//registry.npmjs.org/:_authToken=$NPM_AUTH" > ~/.npmrc
       - git config --global user.email "hello@smooch.io"
       - git config --global user.name "Smooch"
-      - grunt publish
-      - grunt deploy
+      - grunt publish > /dev/null
+      - grunt deploy > /dev/null
 
   staging:
     branch: integration

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "grunt-contrib-concat": "0.5.0",
     "grunt-exec": "0.4.6",
     "grunt-gitinfo": "0.1.7",
-    "grunt-maxcdn": "0.0.3",
     "grunt-release": "jugarrit/grunt-release#master",
     "grunt-s3": "0.2.0-alpha.3",
     "imports-loader": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "express": "4.13.3",
     "file-loader": "0.8.5",
     "grunt": "0.4.5",
-    "grunt-cloudfront": "0.2.1",
+    "grunt-cloudfront": "github:smooch/grunt-cloudfront",
     "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.0",


### PR DESCRIPTION
We're migrating away from MaxCDN to Cloudfront. This is it.