### PR TITLE
Set cache-control headers when uploading to s3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,16 +35,21 @@ module.exports = function(grunt) {
                 key: '<%= aws.key %>',
                 secret: '<%= aws.secret %>',
                 bucket: '<%= aws.bucket %>',
-                access: 'public-read'
+                access: 'public-read',
+                headers: {
+                    'Cache-Control': 'max-age=630720000, public'
+                }
             },
             js: {
                 // Files to be uploaded.
                 upload: [{
                     src: 'dist/smooch.js',
-                    dest: 'smooch.min.js'
-                }, {
-                    src: 'dist/smooch.js.map',
-                    dest: 'smooch.js.map'
+                    dest: 'smooch.min.js',
+                    options: {
+                        headers: {
+                            'Cache-Control': 'max-age=300, public'
+                        }
+                    }
                 }]
             },
             media: {


### PR DESCRIPTION
This will help leverage browser cache with our static assets. I set the value on smooch.min.js to 5 min so it doesn't take too long for a new deployment to roll out.