### PR TITLE
Add Sentry support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,8 @@
     "globals": {
         "VERSION": true,
         "FRAME_JS_URL": true,
-        "FRAME_CSS_URL": true
+        "FRAME_CSS_URL": true,
+        "SENTRY_DSN": true
     },
     "plugins": [
         "react",

--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,0 +1,3 @@
+[defaults]
+org=smoochio
+project=smooch-js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,25 @@ module.exports = function(grunt) {
         exec: {
             createRelease: {
                 cmd: function() {
-                    return 'git checkout -b r/' + this.option('globalVersion');
+                    return [
+                        'git checkout -b r/' + this.option('globalVersion'),
+                        'npm run sentry-cli -- releases new ' + this.option('globalVersion')
+                    ].join(' && ');
+                }
+            },
+            setReleaseCommits: {
+                cmd: function () {
+                    return 'npm run sentry-cli -- releases set-commits ' + this.option('globalVersion') + ' --auto';
+                }
+            },
+            uploadSourceMap: {
+                cmd: function () {
+                    return 'npm run sentry-cli -- releases files ' + this.option('globalVersion') + ' upload-sourcemaps ./dist/';
+                }
+            },
+            finalizeRelease: {
+                cmd: function() {
+                    return 'npm run sentry-cli -- releases finalize ' + this.option('globalVersion');
                 }
             },
             cleanRelease: {
@@ -209,7 +227,7 @@ module.exports = function(grunt) {
     grunt.registerTask('deploy', ['build', 'awsconfig', 's3']);
 
     grunt.registerTask('publish:prepare', ['versionBump', 'exec:commitFiles', 'exec:createRelease', 'build', 'exec:addDist', 'exec:addLib']);
-    grunt.registerTask('publish:release', ['release']);
+    grunt.registerTask('publish:release', ['release', 'exec:setReleaseCommits', 'exec:uploadSourceMap', 'exec:finalizeRelease']);
     grunt.registerTask('publish:cleanup', ['exec:cleanRelease', 'exec:push']);
 
     grunt.registerTask('branchCheck', 'Checks that you are publishing from Master branch with no working changes', ['gitinfo', 'checkBranchStatus']);

--- a/circle.yml
+++ b/circle.yml
@@ -26,12 +26,6 @@ deployment:
       - grunt publish > /dev/null
       - grunt deploy > /dev/null
 
-  staging:
-    branch: integration
-    commands:
-      - npm run build:staging
-      - aws s3 cp dist/smooch.js $SK_JS_STAGING_PATH > /dev/null
-
 
 experimental:
   notify:

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -195,8 +195,10 @@ module.exports = function(options) {
 
     const plugins = [
         new webpack.DefinePlugin({
+            VERSION: `'${VERSION}'`,
             FRAME_JS_URL: `'${publicPath}${frameJsFilename}'`,
-            FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`
+            FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`,
+            SENTRY_DSN: `'${options.sentryDsn}'` || 'undefined'
         })
     ];
 

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -198,7 +198,7 @@ module.exports = function(options) {
             VERSION: `'${VERSION}'`,
             FRAME_JS_URL: `'${publicPath}${frameJsFilename}'`,
             FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`,
-            SENTRY_DSN: `'${options.sentryDsn}'` || 'undefined'
+            SENTRY_DSN: options.sentryDsn ? `'${options.sentryDsn}'` : 'undefined'
         })
     ];
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "optimize-css-assets-webpack-plugin": "2.0.0",
     "phantomjs-prebuilt": "2.1.4",
     "prop-types": "15.5.10",
+    "raven-js": "3.15.0",
     "raw-loader": "0.5.1",
     "react": "15.1.0",
     "react-addons-css-transition-group": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "build:npm": "rm -rf lib && webpack --config webpack-host-npm.config.js --progress --profile --colors",
     "start": "node dev-server/server-production",
     "lint": "eslint . --ext=js --ext=jsx",
-    "dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development"
+    "dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development",
+    "sentry-cli": "sentry-cli"
   },
   "main": "lib/index.js",
   "homepage": "https://smooch.io",
@@ -127,6 +128,7 @@
     "redux-mock-store": "1.0.2",
     "redux-thunk": "2.1.0",
     "semver": "4.3.6",
+    "sentry-cli-binary": "1.13.3",
     "sinon": "2.0.0-pre",
     "sinon-as-promised": "4.0.0",
     "sinon-chai": "2.7.0",

--- a/src/frame/js/index.js
+++ b/src/frame/js/index.js
@@ -1,3 +1,4 @@
 import './utils/polyfills';
+import './utils/raven';
 import * as Smooch from './smooch';
 parent.window.__onLibReady(Smooch);

--- a/src/frame/js/services/core.js
+++ b/src/frame/js/services/core.js
@@ -1,8 +1,6 @@
 import { Smooch } from 'smooch-core/lib/smooch';
 import urljoin from 'urljoin';
 
-import { VERSION } from '../../../shared/js/constants/version';
-
 export function core({auth, appState}) {
     return new Smooch(auth, {
         serviceUrl: urljoin(appState.serverURL, 'v1'),

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -3,6 +3,7 @@ import { render as reactRender } from 'react-dom';
 import pick from 'lodash.pick';
 import { batchActions } from 'redux-batched-actions';
 import { Provider } from 'react-redux';
+import Raven from 'raven-js';
 
 import '../stylesheets/main.less';
 
@@ -215,6 +216,14 @@ export function login(userId = '', jwt, attributes) {
             }
         }
     })).then((loginResponse) => {
+        Raven.setUserContext({
+            id: loginResponse.appUser.userId || loginResponse.appUser._id
+        });
+
+        Raven.setExtraContext({
+            appToken
+        });
+
         const actions = [];
         actions.push(userActions.setUser(loginResponse.appUser));
         actions.push(setApp(loginResponse.app));

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -31,7 +31,6 @@ import { playNotificationSound, isAudioSupported } from './utils/sound';
 import { getDeviceId } from './utils/device';
 import { getIntegration, hasChannels } from './utils/app';
 
-import { VERSION } from '../../shared/js/constants/version';
 import { WIDGET_STATE } from './constants/app';
 
 import { Widget } from './components/widget';

--- a/src/frame/js/utils/raven.js
+++ b/src/frame/js/utils/raven.js
@@ -1,0 +1,11 @@
+import Raven from 'raven-js';
+
+if (SENTRY_DSN) {
+    Raven.config(SENTRY_DSN, {
+        release: VERSION
+    }).install();
+
+    window.onunhandledrejection = function(e) {
+        Raven.captureException(e.reason);
+    };
+}

--- a/src/host/js/smooch.js
+++ b/src/host/js/smooch.js
@@ -1,4 +1,3 @@
-import { VERSION } from '../../shared/js/constants/version';
 import hostStyles from '../stylesheets/iframe.less';
 import { waitForPage } from './utils/dom';
 import { init as initEnquire } from './utils/enquire';

--- a/src/shared/js/constants/version.js
+++ b/src/shared/js/constants/version.js
@@ -1,1 +1,0 @@
-export const VERSION = '3.14.4';

--- a/webpack-frame.config.js
+++ b/webpack-frame.config.js
@@ -1,5 +1,6 @@
 module.exports = require('./make-webpack-config')({
     minimize: true,
     buildType: 'frame',
-    devtool: 'source-map'
+    devtool: 'source-map',
+    sentryDsn: process.env.SENTRY_DSN
 });


### PR DESCRIPTION
This adds Sentry support for the frame part of the widget. The frame runtime is isolated from the host page which means that we wouldn't get any errors from the host. Also, now that the npm version will download the frame lib from the cdn, all of our new installs will have error capture support and will help us track and improve the widget proactively.

The deployment will now require a SENTRY_DSN and a SENTRY_AUTH_TOKEN (already set in Circle so we don't forget at that time) as described in https://docs.sentry.io/learn/cli/configuration/.

The changes to the deployment process are pretty simple, it creates a new release in Sentry, associates the commits with the release, uploads the sourcemap, and finalizes the release (as documented here https://docs.sentry.io/learn/cli/releases/).

I also removed the staging deployment config as it will require a different process anyway with the upcoming changes.