### PR TITLE
Script loader

### DIFF
--- a/config/default/config.json
+++ b/config/default/config.json
@@ -5,5 +5,6 @@
     "USER_ID": "",
     "GIVEN_NAME": "DEFAULT_NAME",
     "SURNAME": "DEFAULT_SURNAME",
-    "EMAIL": "DEFAULT@EMAIL.COM"
+    "EMAIL": "DEFAULT@EMAIL.COM",
+    "minifyLoader": true
 }

--- a/dev-server/SimpleRenderer.js
+++ b/dev-server/SimpleRenderer.js
@@ -5,7 +5,7 @@ var embedded = fs.readFileSync(path.resolve(__dirname, '../dev-site/embedded.htm
 
 function SimpleRenderer(options) {
     this.html = (options.embedded ? embedded : html)
-        .replace('SCRIPT_URL', options.scriptUrl)
+        .replace('LOADER_SCRIPT', options.loaderScript)
         .replace('ROOT_URL', options.data.ROOT_URL || '')
         .replace('APP_TOKEN', options.data.APP_TOKEN || '')
         .replace('GIVEN_NAME', options.data.GIVEN_NAME || '')

--- a/dev-server/server.js
+++ b/dev-server/server.js
@@ -3,7 +3,7 @@ module.exports = function(options) {
     const express = require('express');
     const path = require('path');
     const fs = require('fs');
-    const uglifyJs =  require('uglify-js');
+    const uglifyJs = require('uglify-js');
 
     // require the page rendering logic
     const Renderer = require('./SimpleRenderer.js');
@@ -14,7 +14,7 @@ module.exports = function(options) {
         .replace(
             '\'https://\' + appId + \'.webloader.smooch.io/\'',
             '\'/webloader\''
-        );
+    );
 
     try {
         Object.assign(config, require('../config/config.json'));
@@ -64,14 +64,16 @@ module.exports = function(options) {
 
     app.get('/webloader', function(req, res) {
         res.json({
-            url:  '/_assets/smooch.js'
+            url: '/_assets/smooch.js'
         });
     });
 
     // application
     app.get('/*', function(req, res) {
-        if(config.minifyLoader) {
-            loaderScriptContent = uglifyJs.minify(loaderScriptContent, {compress: false}).code;
+        if (config.minifyLoader) {
+            loaderScriptContent = uglifyJs.minify(loaderScriptContent, {
+                compress: false
+            }).code;
         }
 
         const renderer = new Renderer({

--- a/dev-server/server.js
+++ b/dev-server/server.js
@@ -3,6 +3,8 @@ module.exports = function(options) {
     const express = require('express');
     const path = require('path');
     const fs = require('fs');
+    const uglifyJs =  require('uglify-js');
+
     // require the page rendering logic
     const Renderer = require('./SimpleRenderer.js');
 
@@ -68,6 +70,10 @@ module.exports = function(options) {
 
     // application
     app.get('/*', function(req, res) {
+        if(config.minifyLoader) {
+            loaderScriptContent = uglifyJs.minify(loaderScriptContent, {compress: false}).code;
+        }
+
         const renderer = new Renderer({
             loaderScript: loaderScriptContent,
             data: config

--- a/dev-server/server.js
+++ b/dev-server/server.js
@@ -2,11 +2,17 @@ module.exports = function(options) {
 
     const express = require('express');
     const path = require('path');
-
+    const fs = require('fs');
     // require the page rendering logic
     const Renderer = require('./SimpleRenderer.js');
 
     const config = require('../config/default/config.json');
+    let loaderScriptContent = fs.readFileSync(path.join(__dirname, '../src/loader/index.js')).toString();
+    loaderScriptContent = loaderScriptContent
+        .replace(
+            '\'https://\' + appId + \'.webloader.smooch.io/\'',
+            '\'/webloader\''
+        );
 
     try {
         Object.assign(config, require('../config/config.json'));
@@ -35,8 +41,8 @@ module.exports = function(options) {
 
     app.get('/embedded', function(req, res) {
         const renderer = new Renderer({
-            scriptUrl: '/_assets/smooch.js',
             data: config,
+            loaderScript: loaderScriptContent,
             embedded: true
         });
 
@@ -54,10 +60,16 @@ module.exports = function(options) {
         );
     });
 
+    app.get('/webloader', function(req, res) {
+        res.json({
+            url:  '/_assets/smooch.js'
+        });
+    });
+
     // application
     app.get('/*', function(req, res) {
         const renderer = new Renderer({
-            scriptUrl: '/_assets/smooch.js',
+            loaderScript: loaderScriptContent,
             data: config
         });
 

--- a/dev-site/embedded.html
+++ b/dev-site/embedded.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
   <meta charset="utf-8">
   <title>Embedded Conversation Demo</title>
-<script>
-LOADER_SCRIPT
-</script>
+  <script>
+    LOADER_SCRIPT
+  </script>
   <script>
     /* global Smooch: false */
 

--- a/dev-site/embedded.html
+++ b/dev-site/embedded.html
@@ -5,7 +5,9 @@
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
   <meta charset="utf-8">
   <title>Embedded Conversation Demo</title>
-  <script src="SCRIPT_URL"></script>
+<script>
+LOADER_SCRIPT
+</script>
   <script>
     /* global Smooch: false */
 

--- a/dev-site/index.html
+++ b/dev-site/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>Conversation Demo</title>
     <script>
-    LOADER_SCRIPT
+      LOADER_SCRIPT
     </script>
     <script>
         /* global Smooch: false */

--- a/dev-site/index.html
+++ b/dev-site/index.html
@@ -4,7 +4,9 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
     <title>Conversation Demo</title>
-    <script src="SCRIPT_URL"></script>
+    <script>
+    LOADER_SCRIPT
+    </script>
     <script>
         /* global Smooch: false */
 

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -79,6 +79,9 @@ module.exports = function(options) {
             path.resolve(__dirname, 'src/host/'),
             path.resolve(__dirname, 'src/shared/')
         ],
+        exclude: [
+            path.resolve(__dirname, 'src/host/js/umd.js')
+        ],
         use: [
             {
                 loader: 'babel-loader',

--- a/package.json
+++ b/package.json
@@ -146,9 +146,5 @@
   },
   "browser": {
     "faye": "faye/browser/faye-browser"
-  },
-  "dependencies": {
-    "react": "15.5.4",
-    "react-dom": "15.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "start": "node dev-server/server-production",
     "lint": "eslint . --ext=js --ext=jsx",
     "dev": "nodemon --watch dev-server/ --watch src/index.html --watch src/embedded.html --watch config/config.json dev-server/server-development",
-    "sentry-cli": "sentry-cli"
+    "sentry-cli": "sentry-cli",
+    "uglify:loader": "uglifyjs --mangle -- src/loader/index.js"
   },
   "main": "lib/index.js",
   "homepage": "https://smooch.io",
@@ -134,6 +135,7 @@
     "smooch-core": "3.4.0",
     "stats-webpack-plugin": "0.2.2",
     "style-loader": "0.13.0",
+    "uglify-js": "3.0.16",
     "underscore": "1.8.3",
     "url-loader": "0.5.7",
     "urljoin": "0.1.5",

--- a/src/frame/js/index.js
+++ b/src/frame/js/index.js
@@ -1,4 +1,4 @@
 import './utils/polyfills';
 import './utils/raven';
 import * as Smooch from './smooch';
-parent.window.__onLibReady(Smooch);
+parent.window.__onSmoochFrameReady__(Smooch);

--- a/src/host/js/smooch.js
+++ b/src/host/js/smooch.js
@@ -90,7 +90,7 @@ const Skeleton = {
 function setUp() {
     Lib = undefined;
     iframe = undefined;
-    window.__onLibReady = onSmoochReady;
+    window.__onSmoochFrameReady__ = onSmoochReady;
     for (let func = LIB_FUNCS[0], i = 0; i < LIB_FUNCS.length; func = LIB_FUNCS[++i]) {
         Smooch[func] &&
         delete Smooch[func];
@@ -99,7 +99,7 @@ function setUp() {
 }
 
 function onSmoochReady(_Lib) {
-    window.__onLibReady = function() {};
+    window.__onSmoochFrameReady__ = function() {};
     Lib = _Lib;
     if (!isEmbedded) {
         initEnquire(iframe);

--- a/src/host/js/umd.js
+++ b/src/host/js/umd.js
@@ -11,7 +11,7 @@ import Smooch from './smooch';
     } else {
         // in this case, the host lib must be used in conjunction with
         // the script loader
-        if(root.__onSmoochHostReady__) {
+        if (root.__onSmoochHostReady__) {
             root.__onSmoochHostReady__(factory());
         } else {
             console.error('Script loader not found. Please check out the setup instructions.');

--- a/src/host/js/umd.js
+++ b/src/host/js/umd.js
@@ -4,12 +4,18 @@ import Smooch from './smooch';
     /* global define:false */
     if (typeof define === 'function' && define.amd) {
         define([], function() {
-            return (root.Smooch = factory());
+            return factory();
         });
     } else if (typeof module === 'object' && module.exports) {
         module.exports = factory();
     } else {
-        root.Smooch = factory();
+        // in this case, the host lib must be used in conjunction with
+        // the script loader
+        if(root.__onSmoochHostReady__) {
+            root.__onSmoochHostReady__(factory());
+        } else {
+            console.error('Script loader not found. Please check out the setup instructions.')
+        }
     }
 }(global, () => {
     return Smooch;

--- a/src/host/js/umd.js
+++ b/src/host/js/umd.js
@@ -14,7 +14,7 @@ import Smooch from './smooch';
         if(root.__onSmoochHostReady__) {
             root.__onSmoochHostReady__(factory());
         } else {
-            console.error('Script loader not found. Please check out the setup instructions.')
+            console.error('Script loader not found. Please check out the setup instructions.');
         }
     }
 }(global, () => {

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -1,3 +1,4 @@
+/* eslint no-empty:"off" */
 (function(w, d, globalVarName, appId) {
     var initArgs;
     var onCallArgs = [];
@@ -53,4 +54,4 @@
     req.open('GET', 'https://' + appId + '.webloader.smooch.io/', true);
     req.responseType = 'json';
     req.send();
-})(window, document, 'Smooch', '<APPID>');
+})(window, document, 'Smooch', '<app-id>');

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -2,7 +2,7 @@
     var initArgs;
     var onCallArgs = [];
     var next;
-    var globalVar = w[globalVarName] = {
+    w[globalVarName] = {
         init: function() {
             initArgs = arguments;
             return {
@@ -16,38 +16,11 @@
         }
     };
 
-    // Polyfill for Object.assign from MDN
-    function objectAssign(target, varArgs) {
-        if (target == null) { // TypeError if undefined or null
-            throw new TypeError('Cannot convert undefined or null to object');
-        }
-
-        var to = Object(target);
-
-        for (var index = 1; index < arguments.length; index++) {
-            var nextSource = arguments[index];
-
-            if (nextSource != null) { // Skip over if undefined or null
-                for (var nextKey in nextSource) {
-                    // Avoid bugs when hasOwnProperty is shadowed
-                    if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                        // keep the original context if it's a function
-                        if (typeof nextSource[nextKey] === 'function') {
-                            to[nextKey] = nextSource[nextKey].bind(nextSource);
-                        } else {
-                            to[nextKey] = nextSource[nextKey];
-                        }
-                    }
-                }
-            }
-        }
-        return to;
-    }
-
     w.__onSmoochHostReady__ = function onHostReady(Lib) {
         delete w.__onSmoochHostReady__;
         // hydrate skeleton with all the stuff from the real lib
-        objectAssign(globalVar, Lib);
+        w[globalVarName] = Lib;
+
         if (initArgs) {
             var initCall = Lib.init.apply(Lib, initArgs);
             if (next) {

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -1,0 +1,83 @@
+(function(w, d, globalVarName, appId) {
+    var initArgs;
+    var onCallArgs = [];
+    var next;
+    var globalVar = w[globalVarName] = {
+        init: function() {
+            initArgs = arguments;
+            return {
+                then: function(_next) {
+                    next = _next;
+                }
+            };
+        },
+        on: function() {
+            onCallArgs.push(arguments);
+        }
+    };
+
+    // Polyfill for Object.assign from MDN
+    function objectAssign(target, varArgs) {
+        if (target == null) { // TypeError if undefined or null
+            throw new TypeError('Cannot convert undefined or null to object');
+        }
+
+        var to = Object(target);
+
+        for (var index = 1; index < arguments.length; index++) {
+            var nextSource = arguments[index];
+
+            if (nextSource != null) { // Skip over if undefined or null
+                for (var nextKey in nextSource) {
+                    // Avoid bugs when hasOwnProperty is shadowed
+                    if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                        // keep the original context if it's a function
+                        if (typeof nextSource[nextKey] === 'function') {
+                            to[nextKey] = nextSource[nextKey].bind(nextSource);
+                        } else {
+                            to[nextKey] = nextSource[nextKey];
+                        }
+                    }
+                }
+            }
+        }
+        return to;
+    }
+
+    w.__onSmoochHostReady__ = function onHostReady(Lib) {
+        delete w.__onSmoochHostReady__;
+        // hydrate skeleton with all the stuff from the real lib
+        objectAssign(globalVar, Lib);
+        if (initArgs) {
+            var initCall = Lib.init.apply(Lib, initArgs);
+            if (next) {
+                initCall.then(next);
+            }
+        }
+
+        for (var i = 0; i < onCallArgs.length; i++) {
+            Lib.on.apply(Lib, onCallArgs[i]);
+        }
+    };
+
+    function onLoad() {
+        try {
+            if (this.response.url) {
+                var firstTag = d.getElementsByTagName('script')[0];
+                var tag = d.createElement('script');
+
+                tag.async = true;
+                tag.src = this.response.url;
+                firstTag.parentNode.insertBefore(tag, firstTag);
+            }
+        }
+        catch (e) {}
+    }
+
+    // let's make a request to know which version of the lib to load
+    var req = new XMLHttpRequest();
+    req.addEventListener('load', onLoad);
+    req.open('GET', 'https://' + appId + '.webloader.smooch.io/', true);
+    req.responseType = 'json';
+    req.send();
+})(window, document, 'Smooch', '<APPID>');


### PR DESCRIPTION
This PR adds the script loader that will be used by integrators.

I added a `npm run uglify:loader` that will output the script to be pasted in the docs. This is the final output : 

```
(function(e,n,t,o){var r;var s=[];var a;e[t]={init:function(){r=arguments;return{then:function(e){a=e}}},on:function(){s.push(arguments)}};e.__onSmoochHostReady__=function n(o){delete e.__onSmoochHostReady__;e[t]=o;if(r){var i=o.init.apply(o,r);if(a){i.then(a)}}for(var c=0;c<s.length;c++){o.on.apply(o,s[c])}};function i(){try{if(this.response.url){var e=n.getElementsByTagName("script")[0];var t=n.createElement("script");t.async=true;t.src=this.response.url;e.parentNode.insertBefore(t,e)}}catch(e){}}var c=new XMLHttpRequest;c.addEventListener("load",i);c.open("GET","https://"+o+".webloader.smooch.io/",true);c.responseType="json";c.send()})(window,document,"Smooch","<app-id>");
```

People will have to replace `<app-id>` with their appId and if for some reason they need the global var to be anything else than `Smooch` they can change it too (useful for future white labeling).

The way I set up the dev server, it reads what is in `src/loader/index.js` and put it in the page. By default, it's minified, but you can pass `minifyLoader: false` in your config to have it unminified (for debugging purposes).