### PR TITLE
Add MessageBird

### DIFF
--- a/src/js/actions/integrations-actions.js
+++ b/src/js/actions/integrations-actions.js
@@ -4,6 +4,8 @@ export const SET_WECHAT_QR_CODE = 'SET_WECHAT_QR_CODE';
 export const RESET_INTEGRATIONS = 'RESET_INTEGRATIONS';
 export const SET_TWILIO_INTEGRATION_STATE = 'SET_TWILIO_INTEGRATION_STATE';
 export const RESET_TWILIO_INTEGRATION_STATE = 'RESET_TWILIO_INTEGRATION_STATE';
+export const SET_MESSAGEBIRD_INTEGRATION_STATE = 'SET_MESSAGEBIRD_INTEGRATION_STATE';
+export const RESET_MESSAGEBIRD_INTEGRATION_STATE = 'RESET_MESSAGEBIRD_INTEGRATION_STATE';
 export const SET_VIBER_QR_CODE = 'SET_VIBER_QR_CODE';
 export const SET_TRANSFER_REQUEST_CODE = 'SET_TRANSFER_REQUEST_CODE';
 export const RESET_TRANSFER_REQUEST_CODE = 'RESET_TRANSFER_REQUEST_CODE';
@@ -44,6 +46,19 @@ export function setTwilioIntegrationState(attrs) {
 export function resetTwilioIntegrationState() {
     return {
         type: RESET_TWILIO_INTEGRATION_STATE
+    };
+}
+
+export function setMessageBirdIntegrationState(attrs) {
+    return {
+        type: SET_MESSAGEBIRD_INTEGRATION_STATE,
+        attrs
+    };
+}
+
+export function resetMessageBirdIntegrationState() {
+    return {
+        type: RESET_MESSAGEBIRD_INTEGRATION_STATE
     };
 }
 

--- a/src/js/constants/channels.js
+++ b/src/js/constants/channels.js
@@ -4,11 +4,11 @@ import { fetchTransferRequestCode } from '../services/integrations';
 
 import { integrations as integrationsAssets } from '../constants/assets';
 
-import { fetchViberQRCode, fetchWeChatQRCode, fetchTwilioAttributes } from '../services/integrations';
+import { fetchViberQRCode, fetchWeChatQRCode, fetchTwilioAttributes, fetchMessageBirdAttributes } from '../services/integrations';
 
 import { MessengerChannelContent } from '../components/channels/messenger-channel-content';
 import { EmailChannelContent } from '../components/channels/email-channel-content';
-import { TwilioChannelContent } from '../components/channels/twilio-channel-content';
+import { SMSChannelContent } from '../components/channels/sms-channel-content';
 import { TelegramChannelContent } from '../components/channels/telegram-channel-content';
 import { WeChatChannelContent } from '../components/channels/wechat-channel-content';
 import { ViberChannelContent } from '../components/channels/viber-channel-content';
@@ -43,8 +43,23 @@ export const CHANNEL_DETAILS = {
         isLinkable: true,
         ...integrationsAssets.sms,
         renderPageIfLinked: true,
-        Component: TwilioChannelContent,
+        Component: SMSChannelContent,
         onChannelPage: fetchTwilioAttributes
+    },
+    messagebird: {
+        name: 'SMS',
+        getDescription: ({text, pendingClient}) => {
+            if (pendingClient) {
+                return text.smsChannelPendingDescription.replace('{number}', pendingClient.displayName);
+            }
+
+            return text.smsChannelDescription;
+        },
+        isLinkable: true,
+        ...integrationsAssets.sms,
+        renderPageIfLinked: true,
+        Component: SMSChannelContent,
+        onChannelPage: fetchMessageBirdAttributes
     },
     telegram: {
         name: 'Telegram',
@@ -53,7 +68,7 @@ export const CHANNEL_DETAILS = {
         ...integrationsAssets.telegram,
         Component: TelegramChannelContent,
         onChannelPage: () => fetchTransferRequestCode('telegram'),
-        getURL: (channel) => `https://telegram.me/${channel.username}` 
+        getURL: (channel) => `https://telegram.me/${channel.username}`
     },
     viber: {
         name: 'Viber',

--- a/src/js/reducers/integrations-reducer.js
+++ b/src/js/reducers/integrations-reducer.js
@@ -1,7 +1,7 @@
 import { RESET_APP } from '../actions/app-actions';
 import { RESET } from '../actions/common-actions';
 
-import { SET_ERROR, UNSET_ERROR, SET_WECHAT_QR_CODE, SET_TWILIO_INTEGRATION_STATE, RESET_TWILIO_INTEGRATION_STATE, RESET_INTEGRATIONS, SET_VIBER_QR_CODE, SET_TRANSFER_REQUEST_CODE, RESET_TRANSFER_REQUEST_CODE } from '../actions/integrations-actions';
+import { SET_ERROR, UNSET_ERROR, SET_WECHAT_QR_CODE, SET_TWILIO_INTEGRATION_STATE, RESET_TWILIO_INTEGRATION_STATE, SET_MESSAGEBIRD_INTEGRATION_STATE, RESET_MESSAGEBIRD_INTEGRATION_STATE, RESET_INTEGRATIONS, SET_VIBER_QR_CODE, SET_TRANSFER_REQUEST_CODE, RESET_TRANSFER_REQUEST_CODE } from '../actions/integrations-actions';
 
 const INITIAL_STATE = {
     messenger: {
@@ -13,6 +13,11 @@ const INITIAL_STATE = {
         transferRequestCode: ''
     },
     twilio: {
+        linkState: 'unlinked',
+        appUserNumber: '',
+        hasError: false
+    },
+    messagebird: {
         linkState: 'unlinked',
         appUserNumber: '',
         hasError: false
@@ -77,6 +82,16 @@ export function IntegrationsReducer(state = INITIAL_STATE, action) {
                 }
             };
         case RESET_TWILIO_INTEGRATION_STATE:
+            return INITIAL_STATE;
+        case SET_MESSAGEBIRD_INTEGRATION_STATE:
+            return {
+                ...state,
+                messagebird: {
+                    ...state.messagebird,
+                    ...action.attrs
+                }
+            };
+        case RESET_MESSAGEBIRD_INTEGRATION_STATE:
             return INITIAL_STATE;
         case SET_TRANSFER_REQUEST_CODE:
             return {

--- a/src/js/services/faye.js
+++ b/src/js/services/faye.js
@@ -9,7 +9,7 @@ import { getMessages, disconnectFaye, handleConversationUpdated } from './conver
 import { showSettings, hideChannelPage, hideConnectNotification, showTypingIndicator, hideTypingIndicator } from './app';
 import { getDeviceId } from '../utils/device';
 import { ANIMATION_TIMINGS } from '../constants/styles';
-import { cancelTwilioLink, failTwilioLink } from './integrations';
+import { cancelSMSLink, failSMSLink } from './integrations';
 
 
 let client;
@@ -169,14 +169,14 @@ export function handleUserSubscription({appUser, event}) {
             }
         } else if (event.type === 'link:cancelled') {
             const {platform} = appUser.pendingClients.find((c) => c.id === event.clientId);
-            if (platform === 'twilio') {
-                return dispatch(cancelTwilioLink());
+            if (platform === 'twilio' || platform === 'messagebird') {
+                return dispatch(cancelSMSLink(platform));
             }
         } else if (event.type === 'link:failed') {
             const pendingClient = currentAppUser.pendingClients.find((c) => c.id === event.clientId);
 
-            if (pendingClient && pendingClient.platform === 'twilio') {
-                return dispatch(failTwilioLink(event.err));
+            if (pendingClient && (pendingClient.platform === 'twilio' || pendingClient.platform === 'messagebird')) {
+                return dispatch(failSMSLink(event.err, pendingClient.platform));
             }
         }
 

--- a/src/js/services/integrations.js
+++ b/src/js/services/integrations.js
@@ -10,7 +10,7 @@ import { updateUser } from '../actions/user-actions';
 let fetchingWeChat = false;
 let fetchingViber = false;
 
-function handleLinkFailure(error) {
+function handleLinkFailure(error, type) {
     return (dispatch, getState) => {
         const {ui: {text: {smsTooManyRequestsError, smsTooManyRequestsOneMinuteError, smsBadRequestError, smsUnhandledError}}} = getState();
         const retryAfter = error.headers ? error.headers.get('retry-after') : error.retryAfter;
@@ -221,8 +221,8 @@ export function pingSMSChannel(userId, type) {
 
 export function cancelSMSLink(type) {
     return (dispatch, getState) => {
-        const {user: {pendingClients}, ui: {text: {smsLinkCancelled}}} = getState();
-        const {appuserNumber} = integrations[type]
+        const {user: {pendingClients}, integrations, ui: {text: {smsLinkCancelled}}} = getState();
+        const {appUserNumber} = integrations[type];
         dispatch(batchActions([
             updateUser({
                 pendingClients: pendingClients.filter((pendingClient) => pendingClient.platform !== type)
@@ -236,9 +236,9 @@ export function cancelSMSLink(type) {
     };
 }
 
-export function failTwilioLink(error) {
+export function failSMSLink(error, type) {
     return (dispatch) => {
-        dispatch(handleLinkFailure(error));
+        dispatch(handleLinkFailure(error, type));
     };
 }
 

--- a/src/js/utils/app.js
+++ b/src/js/utils/app.js
@@ -1,5 +1,9 @@
 import { CHANNEL_DETAILS } from '../constants/channels';
 
+function getTimestamp(objectId) {
+    return new Date(parseInt(objectId.toString().slice(0, 8), 16) * 1000);
+}
+
 export function getIntegration(appChannels, type) {
     const appChannelsOfType = appChannels.filter((channel) => channel.type === type);
     return appChannelsOfType.length > 0 ? appChannelsOfType[0] : undefined;
@@ -10,13 +14,36 @@ export function hasChannels({channels}) {
 }
 
 export function getAppChannelDetails(appChannels) {
+    let smsIntegrationDate;
+
     return Object.keys(CHANNEL_DETAILS)
         .map((key) => getIntegration(appChannels, key))
         .filter((channel) => channel)
+        .filter((channel) => {
+            const {name} = CHANNEL_DETAILS[channel.type];
+
+            if (name === 'SMS') {
+                const channelIntegrationDate = getTimestamp(channel._id);
+
+                if (!smsIntegrationDate) {
+                    smsIntegrationDate = channelIntegrationDate;
+                }
+
+                if (smsIntegrationDate.getTime() < channelIntegrationDate.getTime()) {
+                    return false;
+                }
+            }
+
+            return true;
+        })
         .map((channel) => {
+
             return {
                 channel,
-                details: CHANNEL_DETAILS[channel.type]
+                details: {
+                    type: channel.type,
+                    ...CHANNEL_DETAILS[channel.type]
+                }
             };
         });
 }

--- a/src/stylesheets/channels.less
+++ b/src/stylesheets/channels.less
@@ -84,7 +84,7 @@
     }
 }
 
-.twilio-linking {
+.sms-linking {
 
         .phone-number {
             padding-right: 10px;

--- a/test/specs/components/channels/channel.spec.jsx
+++ b/test/specs/components/channels/channel.spec.jsx
@@ -19,7 +19,7 @@ describe('Channel Component', () => {
         });
         Object.keys(CHANNEL_DETAILS).forEach((key) => {
             const details = CHANNEL_DETAILS[key];
-            if (details.Component) {
+            if (details.Component && details.name !== 'SMS') {
                 mockComponent(sandbox, details.Component, 'div', {
                     className: key
                 });

--- a/test/specs/components/channels/sms-channel-component.spec.jsx
+++ b/test/specs/components/channels/sms-channel-component.spec.jsx
@@ -5,11 +5,11 @@ import { mockComponent, wrapComponentWithStore } from '../../../utils/react';
 import { createMockedStore } from '../../../utils/redux';
 import { ReactTelephoneInput } from '../../../../src/js/lib/react-telephone-input';
 
-import { TwilioChannelContent } from '../../../../src/js/components/channels/twilio-channel-content';
+import { SMSChannelContent } from '../../../../src/js/components/channels/sms-channel-content';
 
 const sandbox = sinon.sandbox.create();
 
-describe('Twilio Channel Content Component', () => {
+describe('SMS Channel Content Component', () => {
     let component;
     let mockedStore;
 

--- a/test/specs/components/channels/sms-channel-component.spec.jsx
+++ b/test/specs/components/channels/sms-channel-component.spec.jsx
@@ -54,7 +54,7 @@ describe('SMS Channel Content Component', () => {
             }
         };
         it('should render linked component', () => {
-            component = wrapComponentWithStore(TwilioChannelContent, linkedProps, mockedStore);
+            component = wrapComponentWithStore(SMSChannelContent, linkedProps, mockedStore);
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'linked-state').length.should.eq(1);
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
 
@@ -78,7 +78,7 @@ describe('SMS Channel Content Component', () => {
         };
 
         it('should render unlinked component', () => {
-            component = wrapComponentWithStore(TwilioChannelContent, unlinkedProps, mockedStore);
+            component = wrapComponentWithStore(SMSChannelContent, unlinkedProps, mockedStore);
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(1);
         });
 
@@ -92,7 +92,7 @@ describe('SMS Channel Content Component', () => {
                             appUserNumberValid: appUserNumberValid
                         }
                     };
-                    component = wrapComponentWithStore(TwilioChannelContent, props, mockedStore);
+                    component = wrapComponentWithStore(SMSChannelContent, props, mockedStore);
                     TestUtils.scryRenderedDOMComponentsWithClass(component, 'btn-sk-primary').length.should.eq(appUserNumberValid ? 1 : 0);
 
                     if (appUserNumberValid) {
@@ -113,7 +113,7 @@ describe('SMS Channel Content Component', () => {
                         appUserNumberValid: false
                     }
                 };
-                component = wrapComponentWithStore(TwilioChannelContent, props, mockedStore);
+                component = wrapComponentWithStore(SMSChannelContent, props, mockedStore);
                 const warning = TestUtils.findRenderedDOMComponentWithClass(component, 'warning-message');
                 warning.textContent.should.eq(storeState.ui.text.smsInvalidNumberError);
             });
@@ -127,7 +127,7 @@ describe('SMS Channel Content Component', () => {
                         errorMessage: 'error-message'
                     }
                 };
-                component = wrapComponentWithStore(TwilioChannelContent, props, mockedStore);
+                component = wrapComponentWithStore(SMSChannelContent, props, mockedStore);
                 const warning = TestUtils.findRenderedDOMComponentWithClass(component, 'warning-message');
                 warning.textContent.should.eq(props.channelState.errorMessage);
             });
@@ -146,7 +146,7 @@ describe('SMS Channel Content Component', () => {
         };
 
         it('should render pending component', () => {
-            component = wrapComponentWithStore(TwilioChannelContent, pendingProps, mockedStore);
+            component = wrapComponentWithStore(SMSChannelContent, pendingProps, mockedStore);
             TestUtils.scryRenderedDOMComponentsWithClass(component, 'mockedTelephoneInput').length.should.eq(0);
 
             const appUserPhoneNumber = TestUtils.findRenderedDOMComponentWithClass(component, 'phone-number');

--- a/test/specs/services/integrations.spec.js
+++ b/test/specs/services/integrations.spec.js
@@ -78,9 +78,9 @@ describe('Integrations service', () => {
     });
 
 
-    describe('linkTwilioChannel', () => {
+    describe('linkSMSChannel', () => {
         it('should set the twilio integration to pending state', () => {
-            return mockedStore.dispatch(integrationsService.linkTwilioChannel('1', {
+            return mockedStore.dispatch(integrationsService.linkSMSChannel('1', {
                 type: 'twilio',
                 phoneNumber: '+0123456789'
             })).then(() => {
@@ -94,7 +94,7 @@ describe('Integrations service', () => {
         it('should start faye if user returns with conversationStarted', () => {
             pendingAppUser.conversationStarted = true;
 
-            return mockedStore.dispatch(integrationsService.linkTwilioChannel('1', {
+            return mockedStore.dispatch(integrationsService.linkSMSChannel('1', {
                 type: 'twilio',
                 phoneNumber: '+0123456789'
             })).then(() => {
@@ -104,17 +104,17 @@ describe('Integrations service', () => {
         });
     });
 
-    describe('unlinkTwilioChannel', () => {
-        it('should set the twilio integration state to unlinked', () => {
-            return mockedStore.dispatch(integrationsService.unlinkTwilioChannel('1')).then(() => {
+    describe('unlinkSMSChannel', () => {
+        it('should set the sms integration state to unlinked', () => {
+            return mockedStore.dispatch(integrationsService.unlinkSMSChannel('1', 'twilio')).then(() => {
                 coreMock.appUsers.unlinkChannel.should.have.been.calledWith('1', 'twilio');
             });
         });
     });
 
-    describe('pingTwilioChannel', () => {
+    describe('pingSMSChannel', () => {
         it('should call the ping channel API', () => {
-            return mockedStore.dispatch(integrationsService.pingTwilioChannel('1')).then(() => {
+            return mockedStore.dispatch(integrationsService.pingSMSChannel('1', 'twilio')).then(() => {
                 coreMock.appUsers.pingChannel.should.have.been.calledWith('1', 'twilio');
             });
         });

--- a/test/specs/utils/app.spec.js
+++ b/test/specs/utils/app.spec.js
@@ -95,12 +95,18 @@ describe('App utils', () => {
 
             details[0].should.deep.eq({
                 channel: channel1,
-                details: CHANNEL_DETAILS[channel1.type]
+                details: {
+                    type: channel1.type,
+                    ...CHANNEL_DETAILS[channel1.type]
+                }
             });
 
             details[1].should.deep.eq({
                 channel: channel2,
-                details: CHANNEL_DETAILS[channel2.type]
+                details: {
+                    type: channel2.type,
+                    ...CHANNEL_DETAILS[channel2.type]
+                }
             });
         });
     });


### PR DESCRIPTION
I've made the Twilio page generic so it can be used by MessageBird also. A few function in the integrations service became generic to support both SMS channels.

In order to not display both SMS channels, only the first channel integrated will be displayed, the other will be filtered out.