### PR TITLE
Fix channel and settings page closing issue

### DIFF
--- a/src/frame/js/components/channels/transfer-request-channel-content.jsx
+++ b/src/frame/js/components/channels/transfer-request-channel-content.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { batchActions } from 'redux-batched-actions';
 
-import { hideChannelPage } from '../../services/app';
+import { hideChannelPage } from '../../actions/app-state-actions';
 import { Loading } from '../../components/loading';
 import { resetTransferRequestCode, unsetError } from '../../actions/integrations-actions';
 import { fetchTransferRequestCode } from '../../services/integrations';
@@ -32,7 +32,7 @@ export class TransferRequestChannelContentComponent extends Component {
     }
 
     render() {
-        const {type, channelState, url, transferError} = this.props;
+        const {channelState, url, transferError} = this.props;
         const {transferRequestCode, hasError} = channelState;
 
         if (hasError) {

--- a/src/frame/js/components/header.jsx
+++ b/src/frame/js/components/header.jsx
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { toggleWidget, showSettings, hideSettings, hideChannelPage } from '../services/app';
+import { toggleWidget, showSettings } from '../services/app';
+import { hideSettings, hideChannelPage } from '../actions/app-state-actions';
 import { hasChannels } from '../utils/app';
 import { bindAll } from '../utils/functions';
 import { CHANNEL_DETAILS } from '../constants/channels';


### PR DESCRIPTION
Pure actions that were in `services` were moved to `actions`... we probably should just move everything to `actions` at some point.