### PR TITLE
Remove url from badge filter id

### DIFF
--- a/src/frame/js/components/default-button-icon.jsx
+++ b/src/frame/js/components/default-button-icon.jsx
@@ -1,26 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 import { SK_DARK_CONTRAST } from '../constants/styles';
 
-export class DefaultButtonIconComponent extends Component {
+export class DefaultButtonIcon extends Component {
     static propTypes = {
-        isBrandColorDark: PropTypes.bool.isRequired,
-        location: PropTypes.object.isRequired
+        isBrandColorDark: PropTypes.bool.isRequired
     };
 
     render() {
-        const {isBrandColorDark, location} = this.props;
-
-        const {protocol, host, pathname, search} = location;
+        const {isBrandColorDark} = this.props;
 
         return <svg version='1.0'
                     x='0px'
                     y='0px'
                     viewBox='0 0 100 100'
                     className='default-icon'
-                    style={ {    enableBackground: 'new 0 0 100 100',    overflow: 'visible',    shapeRendering: 'geometricPrecision'} }>
+                    style={ { enableBackground: 'new 0 0 100 100', overflow: 'visible', shapeRendering: 'geometricPrecision' } }>
                    <filter id='33c9df204aeec9aa096f1fd360bd4160'>
                        <feGaussianBlur stdDeviation='0,4'
                                        in='SourceAlpha' />
@@ -39,14 +35,8 @@ export class DefaultButtonIconComponent extends Component {
                        </feMerge>
                    </filter>
                    <path fill={ isBrandColorDark ? '#fff' : SK_DARK_CONTRAST }
-                         filter={ `url(${protocol}//${host}${pathname}${search}#33c9df204aeec9aa096f1fd360bd4160)` }
+                         filter='#33c9df204aeec9aa096f1fd360bd4160'
                          d='M50,0C22.4,0,0,22.4,0,50s22.4,50,50,50h30.8l0-10.6C92.5,80.2,100,66,100,50C100,22.4,77.6,0,50,0z M32,54.5 c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5s4.5,2,4.5,4.5C36.5,52.5,34.5,54.5,32,54.5z M50,54.5c-2.5,0-4.5-2-4.5-4.5 c0-2.5,2-4.5,4.5-4.5c2.5,0,4.5,2,4.5,4.5C54.5,52.5,52.5,54.5,50,54.5z M68,54.5c-2.5,0-4.5-2-4.5-4.5c0-2.5,2-4.5,4.5-4.5 s4.5,2,4.5,4.5C72.5,52.5,70.5,54.5,68,54.5z' />
                </svg>;
     }
 }
-
-export const DefaultButtonIcon = connect(({browser: {currentLocation}}) => {
-    return {
-        location: currentLocation
-    };
-})(DefaultButtonIconComponent);

--- a/test/specs/components/messenger-button.spec.js
+++ b/test/specs/components/messenger-button.spec.js
@@ -3,7 +3,7 @@ import TestUtils from 'react-addons-test-utils';
 import deepAssign from 'deep-assign';
 
 import { MessengerButton } from '../../../src/frame/js/components/messenger-button';
-import { DefaultButtonIconComponent } from '../../../src/frame/js/components/default-button-icon';
+import { DefaultButtonIcon } from '../../../src/frame/js/components/default-button-icon';
 
 import { mockComponent, wrapComponentWithStore } from '../../utils/react';
 import { createMockedStore } from '../../utils/redux';
@@ -34,7 +34,7 @@ function getStoreState(state = {}) {
 describe('Messenger Button Component', () => {
     let mockedStore;
     beforeEach(() => {
-        mockComponent(sandbox, DefaultButtonIconComponent, 'div', {
+        mockComponent(sandbox, DefaultButtonIcon, 'div', {
             className: 'mockedDefaultButtonIcon'
         });
     });


### PR DESCRIPTION
The main problem FF had with the svg was how it would find the filter by id. Now that it's in an iframe, it doesn't have a problem finding it without the whole url as a reference.