### PR TITLE
Fix box-shadow and responsiveness handling in FF

### DIFF
--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -30,7 +30,7 @@ import { waitForPage, monitorUrlChanges, stopMonitoringUrlChanges, monitorBrowse
 import { isImageUploadSupported } from './utils/media';
 import { playNotificationSound, isAudioSupported } from './utils/sound';
 import { getDeviceId } from './utils/device';
-import { getIntegration, hasChannels } from './utils/app';
+import { getIntegration } from './utils/app';
 
 import { WIDGET_STATE } from './constants/app';
 
@@ -44,7 +44,7 @@ let unsubscribeFromStore;
 
 // Listen for media query changes from the host page.
 window.addEventListener('message', ({data, origin}) => {
-    if (origin === `${location.protocol}//${location.host}`) {
+    if (origin === `${parent.document.location.protocol}//${parent.document.location.host}`) {
         if (data.type === 'sizeChange') {
             store.dispatch(AppStateActions.updateWidgetSize(data.value));
         }
@@ -201,12 +201,12 @@ export function login(userId = '', jwt, attributes) {
             id: getDeviceId(),
             info: {
                 sdkVersion: VERSION,
-                URL: document.location.host,
+                URL: parent.document.location.host,
                 userAgent: navigator.userAgent,
-                referrer: document.referrer,
+                referrer: parent.document.referrer,
                 browserLanguage: navigator.language,
-                currentUrl: document.location.href,
-                currentTitle: document.title
+                currentUrl: parent.document.location.href,
+                currentTitle: parent.document.title
             }
         }
     })).then((loginResponse) => {
@@ -222,10 +222,10 @@ export function login(userId = '', jwt, attributes) {
         actions.push(userActions.setUser(loginResponse.appUser));
         actions.push(setApp(loginResponse.app));
 
-        actions.push(setCurrentLocation(document.location));
+        actions.push(setCurrentLocation(parent.document.location));
         monitorUrlChanges(() => {
             const actions = [
-                setCurrentLocation(document.location),
+                setCurrentLocation(parent.document.location),
                 userService.updateNowViewing(getDeviceId())
             ];
 

--- a/src/frame/stylesheets/conversation.less
+++ b/src/frame/stylesheets/conversation.less
@@ -2,7 +2,7 @@
     position: relative;
     padding: 0;
     height: @conversation-height;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
     .transition(padding-top 500ms);

--- a/src/frame/stylesheets/main.less
+++ b/src/frame/stylesheets/main.less
@@ -59,7 +59,7 @@ html, body {
         background: @background-color;
         position: relative;
         border-radius: 10px;
-        box-shadow: 0 0 24px rgba(0,0,0,0.15);
+        box-shadow: 0 0 @widget-box-shadow-width rgba(0,0,0,0.15);
         border: 1px solid rgba(0,0,0,0.15);
         .widget-size();
 


### PR DESCRIPTION
FF wasn't responding to the responsive events from the host since the location inside the iframe is always `about://blank`. By using `parent.document.location` we're able to listen to the events properly. Also, box-shadow was ugly... fixed it.

iframes yay!