### PR TITLE
Stripe Refactor

### DIFF
--- a/.esformatter
+++ b/.esformatter
@@ -303,8 +303,7 @@
     "esformatter-quotes",
     "esformatter-braces",
     "esformatter-dot-notation",
-    "esformatter-jsx",
-    "esformatter-semicolons"
+    "esformatter-jsx"
   ],
   "quotes": {
     "type": "single",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "esformatter-dot-notation": "1.3.1",
     "esformatter-jsx": "8.0.0",
     "esformatter-quotes": "1.0.3",
-    "esformatter-semicolons": "1.1.2",
     "eslint": "3.19.0",
     "eslint-plugin-mocha": "4.10.1",
     "eslint-plugin-react": "7.0.1",

--- a/src/frame/js/actions/stripe.js
+++ b/src/frame/js/actions/stripe.js
@@ -13,10 +13,3 @@ export function createTransaction(actionId, token) {
         });
     };
 }
-
-export function getAccount() {
-    return (dispatch, getState) => {
-        const {config: {appId}, user: {_id}} = getState();
-        return dispatch(http('GET', `/apps/${appId}/appusers/${_id}/stripe/customer`));
-    };
-}

--- a/src/frame/js/components/Action.jsx
+++ b/src/frame/js/components/Action.jsx
@@ -15,6 +15,10 @@ import Loading from './Loading';
 export class ActionComponent extends Component {
 
     static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+        _id: PropTypes.string.isRequired,
+        appName: PropTypes.string.isRequired,
+        appIconUrl: PropTypes.string.isRequired,
         text: PropTypes.string.isRequired,
         type: PropTypes.string,
         buttonColor: PropTypes.string,
@@ -24,7 +28,6 @@ export class ActionComponent extends Component {
         state: PropTypes.string,
         actionPaymentCompletedText: PropTypes.string.isRequired,
         integrations: PropTypes.array.isRequired,
-        stripe: PropTypes.object,
         user: PropTypes.object.isRequired
     };
 
@@ -115,7 +118,7 @@ export class ActionComponent extends Component {
     }
 
     render() {
-        const {buttonColor, amount, currency, text, uri, type, actionPaymentCompletedText, integrations, stripe, user} = this.props;
+        const {buttonColor, amount, currency, text, uri, type, actionPaymentCompletedText, integrations, user, appName, appIconUrl} = this.props;
         const {state} = this.state;
 
         const stripeIntegration = getIntegration(integrations, 'stripeConnect');
@@ -129,8 +132,6 @@ export class ActionComponent extends Component {
         // the public key is necessary to use with Checkout
         // use the link fallback if this happens
         if (type === 'buy' && stripeIntegration) {
-            // let's change this when we support other providers
-            const stripeAccount = stripe;
             if (state === 'offered') {
                 return <StripeCheckout componentClass='div'
                                        className='sk-action'
@@ -139,8 +140,8 @@ export class ActionComponent extends Component {
                                        email={ user.email }
                                        amount={ amount }
                                        currency={ currency.toUpperCase() }
-                                       name={ stripeAccount.appName }
-                                       image={ stripeAccount.iconUrl }
+                                       name={ appName }
+                                       image={ appIconUrl }
                                        closed={ this.onStripeClose }
                                        executionContext={ parent }>
                            <a className='btn btn-sk-primary'
@@ -200,7 +201,9 @@ export default connect(({ui: {text}, user, config}) => {
         user,
         actionPaymentCompletedText: text.actionPaymentCompleted,
         integrations: config.integrations,
-        stripe: config.stripe
+        stripe: config.stripe,
+        appName: config.app.name,
+        appIconUrl: config.app.iconUrl,
     };
 }, null, null, {
     withRef: true

--- a/src/frame/js/components/Action.jsx
+++ b/src/frame/js/components/Action.jsx
@@ -203,7 +203,7 @@ export default connect(({ui: {text}, user, config}) => {
         integrations: config.integrations,
         stripe: config.stripe,
         appName: config.app.name,
-        appIconUrl: config.app.iconUrl,
+        appIconUrl: config.app.iconUrl
     };
 }, null, null, {
     withRef: true

--- a/src/frame/js/components/Action.jsx
+++ b/src/frame/js/components/Action.jsx
@@ -201,7 +201,6 @@ export default connect(({ui: {text}, user, config}) => {
         user,
         actionPaymentCompletedText: text.actionPaymentCompleted,
         integrations: config.integrations,
-        stripe: config.stripe,
         appName: config.app.name,
         appIconUrl: config.app.iconUrl
     };

--- a/test/specs/actions/stripe.spec.js
+++ b/test/specs/actions/stripe.spec.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
 
-import { createTransaction, getAccount, __Rewire__ as StripeRewire } from '../../../src/frame/js/actions/stripe';
+import { createTransaction, __Rewire__ as StripeRewire } from '../../../src/frame/js/actions/stripe';
 
 describe('Stripe Actions', () => {
     let sandbox;

--- a/test/specs/actions/stripe.spec.js
+++ b/test/specs/actions/stripe.spec.js
@@ -38,13 +38,4 @@ describe('Stripe Actions', () => {
             });
         });
     });
-
-    describe('getAccount', () => {
-        it('should call stripe api endpoint', () => {
-            const {config: {appId}, user: {_id}} = mockedStore.getState();
-            return mockedStore.dispatch(getAccount()).then(() => {
-                httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${_id}/stripe/customer`);
-            });
-        });
-    });
 });

--- a/test/specs/components/Action.spec.js
+++ b/test/specs/components/Action.spec.js
@@ -58,6 +58,13 @@ function getStoreState(state = {}) {
                 actionPaymentCompleted: 'payment completed text'
             },
             ...state.ui
+        },
+        config: {
+            app: {
+                name: 'app-name',
+                iconUrl: 'iconUrl'
+            },
+            ...state.config
         }
     });
 }
@@ -146,8 +153,8 @@ describe('Action Component', () => {
                         type: 'stripeConnect'
                     }
                 ],
-                stripe: {
-                    appName: 'app-name',
+                app: {
+                    name: 'app-name',
                     iconUrl: 'iconUrl'
                 }
             }
@@ -226,11 +233,7 @@ describe('Action Component', () => {
                                 {
                                     type: 'stripeConnect'
                                 }
-                            ],
-                            stripe: {
-                                appName: 'app-name',
-                                iconUrl: 'iconUrl'
-                            }
+                            ]
                         },
                         user: {
                             email: ''
@@ -356,12 +359,6 @@ describe('Action Component', () => {
     describe('buy action without stripe keys', () => {
         const props = getBuyProps();
         const storeState = getStoreState({
-            app: {
-                stripe: {
-                    appName: 'app-name',
-                    iconUrl: 'iconUrl'
-                }
-            },
             ui: {
                 text: {
                     actionPaymentCompleted: 'payment completed text'

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -31,6 +31,7 @@ export function generateBaseStoreProps(extraProps = {}) {
             appId: 'some-app-id',
             apiBaseUrl: 'http://localhost',
             configBaseUrl: 'http://localhost',
+            app: {},
             style: {},
             integrations: [],
             realtime: {},


### PR DESCRIPTION
This makes the widget use the appName and iconUrl from the config.

Also, I remove esformatter-semicolons because it wasn't working with jsx.