### PR TITLE
Handle linking events where current user is the survivor

### DIFF
--- a/src/frame/js/actions/app-state.js
+++ b/src/frame/js/actions/app-state.js
@@ -1,4 +1,5 @@
-import { resetUnreadCount, connectFayeUser } from './conversation';
+import { resetUnreadCount } from './conversation';
+import { subscribe as subscribeFaye } from './faye';
 import { observable } from '../utils/events';
 import { hasLinkableChannels, isChannelLinked } from '../utils/user';
 import { getIntegration } from '../utils/app';
@@ -33,17 +34,6 @@ export const HIDE_TYPING_INDICATOR = 'HIDE_TYPING_INDICATOR';
 export const UPDATE_WIDGET_SIZE = 'UPDATE_WIDGET_SIZE';
 export const SET_INITIALIZATION_STATE = 'SET_INITIALIZATION_STATE';
 
-function connectToFayeUser() {
-    return (dispatch, getState) => {
-        const {app: {integrations: appChannels, settings}, user: {clients}} = getState();
-
-        if (hasLinkableChannels(appChannels, clients, settings.web)) {
-            return dispatch(connectFayeUser());
-        }
-
-        return Promise.resolve();
-    };
-}
 
 export function toggleWidget() {
     return (dispatch, getState) => {
@@ -88,7 +78,7 @@ export function showSettings() {
         dispatch({
             type: SHOW_SETTINGS
         });
-        return dispatch(connectToFayeUser());
+        return dispatch(subscribeFaye());
     };
 }
 
@@ -181,7 +171,7 @@ export function setEmbedded(value) {
 
 export function showChannelPage(channelType) {
     return (dispatch, getState) => {
-        const {user, app: {integrations}} = getState();
+        const {user, config: {integrations}} = getState();
         const channelDetails = CHANNEL_DETAILS[channelType];
         const isLinked = isChannelLinked(user.clients, channelType);
         const appChannel = getIntegration(integrations, channelType);
@@ -191,7 +181,7 @@ export function showChannelPage(channelType) {
         if (openLink) {
             window.open(url);
             if (!isLinked && channelDetails.isLinkable) {
-                return dispatch(connectToFayeUser());
+                return dispatch(subscribeFaye());
             }
         } else {
             dispatch({
@@ -199,7 +189,7 @@ export function showChannelPage(channelType) {
                 channelType
             });
 
-            return dispatch(connectToFayeUser())
+            return dispatch(subscribeFaye())
                 .then(() => dispatch(channelDetails.onChannelPage()));
         }
     };

--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -7,6 +7,7 @@ import { disconnectClient, subscribe as subscribeFaye, unsetFayeSubscription } f
 
 import http from './http';
 import { setAuth } from './auth';
+import { setConfig } from './config';
 
 import { observable } from '../utils/events';
 import { Throttle } from '../utils/throttle';
@@ -504,7 +505,7 @@ export function disconnectFaye() {
     };
 }
 
-export function handleUserConversationResponse({appUser, conversation, hasPrevious, messages, sessionToken}) {
+export function handleUserConversationResponse({appUser, conversation, hasPrevious, messages, sessionToken, settings}) {
     return (dispatch, getState) => {
         const {config: {appId}} = getState();
         Raven.setUserContext({
@@ -519,6 +520,10 @@ export function handleUserConversationResponse({appUser, conversation, hasPrevio
             }),
             setMessages(messages)
         ];
+
+        for (const key of Object.keys(settings)) {
+            actions.push(setConfig(key, settings[key]));
+        }
 
         storage.setItem(`${appId}.appUserId`, appUser._id);
 

--- a/src/frame/js/actions/faye.js
+++ b/src/frame/js/actions/faye.js
@@ -145,7 +145,12 @@ function handleActivityEvents(events) {
 export function subscribe() {
     return (dispatch, getState) => {
         const client = dispatch(getClient());
-        const {config: {appId}, user: {_id}} = getState();
+        const {config: {appId}, user: {_id}, faye: {subscription: existingSubscription}} = getState();
+
+        if (existingSubscription) {
+            return existingSubscription;
+        }
+
         const subscription = client.subscribe(`/sdk/apps/${appId}/appusers/${_id}`, function({events}) {
             const messageEvents = events.filter(({type}) => type === 'message');
             const activityEvents = events.filter(({type}) => type === 'activity');

--- a/src/frame/js/components/NotificationChannelItem.jsx
+++ b/src/frame/js/components/NotificationChannelItem.jsx
@@ -7,6 +7,7 @@ import { bindAll } from '../utils/functions';
 
 export class NotificationChannelItemComponent extends Component {
     static propTypes = {
+        dispatch: PropTypes.func.isRequired,
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         linked: PropTypes.bool.isRequired,
@@ -68,9 +69,9 @@ export class NotificationChannelItemComponent extends Component {
     }
 }
 
-export default connect(({app, ui}) => {
+export default connect(({config, ui}) => {
     return {
-        linkColor: app.settings.web.linkColor,
+        linkColor: config.style.linkColor,
         notificationSettingsConnectedAsText: ui.text.notificationSettingsConnectedAs,
         notificationSettingsConnectedText: ui.text.notificationSettingsConnected
     };

--- a/src/frame/js/components/Settings.jsx
+++ b/src/frame/js/components/Settings.jsx
@@ -57,9 +57,9 @@ export class SettingsComponent extends Component {
     }
 }
 
-export default connect(({app, user, ui}) => {
+export default connect(({config, user, ui}) => {
     return {
-        appChannels: app.integrations,
+        appChannels: config.integrations,
         notificationSettingsChannelsTitleText: ui.text.notificationSettingsChannelsTitle,
         notificationSettingsChannelsDescriptionText: ui.text.notificationSettingsChannelsDescription,
         user

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -175,20 +175,29 @@ export function init(props = {}) {
 
     return store.dispatch(fetchConfig())
         .then(() => {
-            if (props.userId && props.jwt) {
-                return login(props.userId, props.jwt);
+            const {config: {app: {status}}} = store.getState();
+
+            if (status !== 'active') {
+                return Promise.resolve();
             }
 
-            if (appUserId && sessionToken) {
-                return store.dispatch(fetchUserConversation());
-            }
-        })
-        .then(() => {
-            if (!props.embedded) {
-                render();
-            }
+            return Promise.resolve()
+                .then(() => {
+                    if (props.userId && props.jwt) {
+                        return login(props.userId, props.jwt);
+                    }
 
-            observable.trigger('ready');
+                    if (appUserId && sessionToken) {
+                        return store.dispatch(fetchUserConversation());
+                    }
+                })
+                .then(() => {
+                    if (!props.embedded) {
+                        render();
+                    }
+
+                    observable.trigger('ready');
+                });
         })
         .catch((err) => {
             Raven.captureException(err);

--- a/test/specs/components/NotificationChannelItem.spec.jsx
+++ b/test/specs/components/NotificationChannelItem.spec.jsx
@@ -29,11 +29,9 @@ describe('Notification Channel Item Component', () => {
                     linked: linked
                 });
                 mockedStore = createMockedStore(sandbox, {
-                    app: {
-                        settings: {
-                            web: {
-                                linkColor: '#00000'
-                            }
+                    config: {
+                        style: {
+                            linkColor: '#00000'
                         }
                     },
                     ui: {

--- a/test/specs/components/Settings.spec.jsx
+++ b/test/specs/components/Settings.spec.jsx
@@ -18,7 +18,7 @@ describe('Settings', () => {
     let getAppChannelDetailsStub;
 
     const defaultStoreProps = {
-        app: {
+        config: {
             integrations: [
                 {
                     _id: 1,

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -32,7 +32,13 @@ function restoreAppStore() {
     });
 }
 
-const defaultState = generateBaseStoreProps();
+const defaultState = generateBaseStoreProps({
+    config: {
+        app: {
+            status: 'active'
+        }
+    }
+});
 
 describe('Smooch', () => {
     const sandbox = sinon.sandbox.create();

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -20,6 +20,7 @@ export function generateBaseStoreProps(extraProps = {}) {
         },
         user: {
             pendingClients: [],
+            clients: [],
             ...extraProps.user
         },
         appState: {


### PR DESCRIPTION
This brings back handling of the linking event in the case the linking didn't replace the current user.

The other case will be handled is in another PR.

I also add to fix some components to use the new store structure in order to make some part of the widget appear.