### PR TITLE
Add back Twilio and MessageBird linking

### DIFF
--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -505,7 +505,7 @@ export function disconnectFaye() {
     };
 }
 
-export function handleUserConversationResponse({appUser, conversation, hasPrevious, messages, sessionToken, settings}) {
+export function handleUserConversationResponse({appUser, conversation, hasPrevious, messages=[], sessionToken, settings}) {
     return (dispatch, getState) => {
         const {config: {appId}} = getState();
         Raven.setUserContext({

--- a/src/frame/js/actions/faye.js
+++ b/src/frame/js/actions/faye.js
@@ -162,7 +162,7 @@ function updateUser(currentAppUser, nextAppUser, client) {
 
 function handleLinkEvents(events) {
     return (dispatch, getState) => {
-        events.forEach(({type, appUser, client}) => {
+        events.forEach(({type, appUser, client, err}) => {
             const {user: currentAppUser, appState: {visibleChannelType}} = getState();
 
             if (type === 'link') {
@@ -190,7 +190,7 @@ function handleLinkEvents(events) {
                 }
             } else if (type === 'link:failed') {
                 if (client && (client.platform === 'twilio' || client.platform === 'messagebird')) {
-                    return dispatch(failSMSLink(event.err, client.platform));
+                    return dispatch(failSMSLink(err, client.platform));
                 }
             }
         });

--- a/test/specs/actions/integrations.spec.js
+++ b/test/specs/actions/integrations.spec.js
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import hat from 'hat';
 
 import { createMock as createThrottleMock } from '../../mocks/throttle';
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
@@ -44,12 +45,21 @@ describe('Integrations Actions', () => {
 
 
     describe('linkSMSChannel', () => {
+        let conversationId;
+
         beforeEach(() => {
             httpStub.returnsAsyncThunk({
                 value: {
                     client: {}
                 }
             });
+
+            conversationId = hat();
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                conversation: {
+                    _id: conversationId
+                }
+            }));
         });
 
         it('should set the twilio integration to pending state', () => {
@@ -59,8 +69,16 @@ describe('Integrations Actions', () => {
                 phoneNumber: '+0123456789'
             })).then(() => {
                 httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${_id}/clients`, {
-                    type: 'twilio',
-                    phoneNumber: '+0123456789'
+                    criteria: {
+                        type: 'twilio',
+                        phoneNumber: '+0123456789'
+                    },
+                    confirmation: {
+                        type: 'prompt'
+                    },
+                    target: {
+                        conversationId
+                    }
                 });
             });
         });
@@ -74,7 +92,7 @@ describe('Integrations Actions', () => {
                     clients: [
                         {
                             platform: 'twilio',
-                            _id: 'twilio-client'
+                            id: 'twilio-client'
                         }
                     ],
                     pendingClients: []
@@ -98,7 +116,7 @@ describe('Integrations Actions', () => {
                     clients: [
                         {
                             platform: 'twilio',
-                            _id: 'twilio-client'
+                            id: 'twilio-client'
                         }
                     ],
                     pendingClients: []


### PR DESCRIPTION
1. Updated the format of the `POST /clients` call to include all
   required props
2. Fix handling of link errors to correctly use the returned error
3. Fix handling of link cancellations - apparently `batchActions`
   doesn't play nice with async actions
4. Change ping and unlink calls to use `clients.id` instead of
   `clients._id`
5. Fix fresh user creation - there is no messages array returned, but
   we were expecting it to exist.