### PR TITLE
Handle link event when the appUser _id changes

### DIFF
--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -516,7 +516,7 @@ export function handleUserConversationResponse({appUser, conversation, hasPrevio
             setUser(appUser),
             setConversation({
                 ...conversation,
-                hasMoreMessages: hasPrevious
+                hasMoreMessages: !!hasPrevious
             }),
             setMessages(messages)
         ];

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -188,7 +188,20 @@ export function init(props = {}) {
                     }
 
                     if (appUserId && sessionToken) {
-                        return store.dispatch(fetchUserConversation());
+                        return store.dispatch(fetchUserConversation())
+                            .catch((err) => {
+                                if (err.code === 'invalid_auth') {
+                                    storage.removeItem(`${props.appId}.appUserId`);
+                                    storage.removeItem(`${props.appId}.sessionToken`);
+
+                                    return store.dispatch(batchActions([
+                                        authActions.resetAuth(),
+                                        userActions.resetUser()
+                                    ]));
+                                } else {
+                                    throw err;
+                                }
+                            });
                     }
                 })
                 .then(() => {


### PR DESCRIPTION
When a link completes, it's possible for an appUser's `_id` to change.
The SDK should be aware of this and be able to recover from such a
change. I've added two new pieces of logic:

1. When a `link` event comes through faye and the user _id changes,
   we change internal state to point to the new user, and
   re-initialize (via login if the user has a `userId`, or via a user
   fetch if the user is using a `sessionToken`)
2. When initializing the SDK with an anonymous user, if the server
   returns an `invalid_auth` error (e.g. if the stored appUserId or
   sessionToken are invalid), we clear any local state and allow
   execution to continue with a new anonymous user. This covers the
   case where an anonymous user has been merged out of existence via
   linking.