### PR TITLE
Add proper handling of switch user flows

### DIFF
--- a/src/frame/js/actions/auth.js
+++ b/src/frame/js/actions/auth.js
@@ -1,29 +1,78 @@
-import http from './http';
-import { handleUserConversationResponse } from './conversation';
+import { batchActions } from 'redux-batched-actions';
 
-import { getClientInfo } from '../utils/client';
+import http from './http';
+import { resetConversation, handleUserConversationResponse, disconnectFaye } from './conversation';
+import { setUser, resetUser } from './user';
+
+import { getClientId, getClientInfo } from '../utils/client';
 import { removeItem } from '../utils/storage';
 
 export const SET_AUTH = 'SET_AUTH';
 export const RESET_AUTH = 'RESET_AUTH';
 
-export function login() {
+export function login(userId, jwt) {
     return (dispatch, getState) => {
-        const {config: {appId}, user: {userId}, auth: {sessionToken}} = getState();
+        const {config: {appId}, auth: {sessionToken}} = getState();
+
+        const actions = [
+            setAuth({
+                jwt
+            }),
+            setUser({
+                userId
+            }),
+            resetConversation()
+        ];
+
+        dispatch(disconnectFaye());
+        dispatch(batchActions(actions));
+
         return dispatch(http('POST', `/apps/${appId}/login`, {
             userId,
             sessionToken,
             client: getClientInfo(appId)
-        })).then(({response, ...props}) => {
+        })).then((response) => {
             // get rid of session token
             removeItem(`${appId}.sessionToken`);
-            dispatch(setAuth({
-                sessionToken: null
-            }));
 
-            if (response.status === 200) {
-                return dispatch(handleUserConversationResponse(props));
+            if (response && Object.keys(response).length > 0) {
+                return dispatch(handleUserConversationResponse(response));
             }
+        });
+    };
+}
+
+export function logout() {
+    return (dispatch, getState) => {
+        const {config: {appId}, user: {_id: appUserId, userId}} = getState();
+
+        if (!userId) {
+            return Promise.resolve();
+        }
+
+        let promise;
+        if (appUserId) {
+            promise = dispatch(http('POST', `/apps/${appId}/appusers/${appUserId}/logout`, {
+                client: {
+                    id: getClientId(appId)
+                }
+            }));
+        } else {
+            promise = Promise.resolve();
+        }
+
+        return promise.then(() => {
+            const actions = [
+                resetAuth(),
+                resetUser(),
+                resetConversation()
+            ];
+
+            dispatch(disconnectFaye());
+            dispatch(batchActions(actions));
+
+            removeItem(`${appId}.appUserId`);
+            removeItem(`${appId}.sessionToken`);
         });
     };
 }

--- a/src/frame/js/actions/auth.js
+++ b/src/frame/js/actions/auth.js
@@ -3,6 +3,7 @@ import { batchActions } from 'redux-batched-actions';
 import http from './http';
 import { resetConversation, handleUserConversationResponse, disconnectFaye } from './conversation';
 import { setUser, resetUser } from './user';
+import { resetIntegrations } from './integrations';
 
 import { getClientId, getClientInfo } from '../utils/client';
 import { removeItem } from '../utils/storage';
@@ -21,7 +22,8 @@ export function login(userId, jwt) {
             setUser({
                 userId
             }),
-            resetConversation()
+            resetConversation(),
+            resetIntegrations()
         ];
 
         dispatch(disconnectFaye());
@@ -65,7 +67,8 @@ export function logout() {
             const actions = [
                 resetAuth(),
                 resetUser(),
-                resetConversation()
+                resetConversation(),
+                resetIntegrations()
             ];
 
             dispatch(disconnectFaye());

--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -546,18 +546,19 @@ export function handleUserConversationResponse({appUser, conversation, hasPrevio
 
 export function startConversation() {
     return (dispatch, getState) => {
-        const {user: {_id: userId, pendingAttributes}, config: {appId}, conversation: {_id: conversationId}} = getState();
+        const {user: {_id: appUserId, userId, pendingAttributes}, config: {appId}, conversation: {_id: conversationId}} = getState();
 
         if (conversationId) {
             return Promise.resolve();
         }
 
         let promise;
-        if (userId) {
-            promise = dispatch(http('POST', `/appusers/${userId}/conversations`));
+        if (appUserId) {
+            promise = dispatch(http('POST', `/appusers/${appUserId}/conversations`));
         } else {
             promise = dispatch(http('POST', `/apps/${appId}/appusers`, {
                 ...pendingAttributes,
+                userId,
                 client: getClientInfo(appId)
             }));
         }

--- a/src/frame/js/components/channels/Channel.jsx
+++ b/src/frame/js/components/channels/Channel.jsx
@@ -58,7 +58,7 @@ export default connect(({appState, config, user, integrations}) => {
         appChannels: config.integrations,
         channelStates: integrations,
         smoochId: user._id,
-        clients: user.clients,
-        pendingClients: user.pendingClients
+        clients: user.clients || [],
+        pendingClients: user.pendingClients || []
     };
 })(ChannelComponent);

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -223,22 +223,11 @@ export function login(userId, jwt) {
         throw new Error('Must provide a userId and a jwt to log in.');
     }
 
-    const actions = [
-        authActions.setAuth({
-            jwt
-        }),
-        userActions.setUser({
-            userId
-        })
-    ];
-
-    store.dispatch(batchActions(actions));
-
-    return store.dispatch(authActions.login());
+    return store.dispatch(authActions.login(userId, jwt));
 }
 
 export function logout() {
-    return login();
+    return store.dispatch(authActions.logout());
 }
 
 export function sendMessage(props) {

--- a/test/specs/actions/auth.spec.js
+++ b/test/specs/actions/auth.spec.js
@@ -1,15 +1,25 @@
 import sinon from 'sinon';
+import hat from 'hat';
 
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
-import { login, __Rewire__ as AuthRewire } from '../../../src/frame/js/actions/auth';
+import { login, logout, setAuth, resetAuth, __Rewire__ as AuthRewire } from '../../../src/frame/js/actions/auth';
+import { setUser, resetUser } from '../../../src/frame/js/actions/user';
+import { resetConversation } from '../../../src/frame/js/actions/conversation';
 
 describe('Auth Actions', () => {
     let mockedStore;
     let sandbox;
     let httpStub;
     let getClientInfoStub;
+    let getClientIdStub;
     let handleUserConversationResponseStub;
     let removeItemStub;
+    let resetConversationSpy;
+    let disconnectFayeStub;
+    let setUserSpy;
+    let resetUserSpy;
+    let resetAuthSpy;
+    let setAuthSpy;
 
     before(() => {
         sandbox = sinon.sandbox.create();
@@ -18,24 +28,40 @@ describe('Auth Actions', () => {
     beforeEach(() => {
         httpStub = sandbox.stub().returnsAsyncThunk({
             value: {
-                response: {
-                    status: 200
-                }
+                appUser: {}
             }
         });
         handleUserConversationResponseStub = sandbox.stub().returnsAsyncThunk();
         getClientInfoStub = sandbox.stub().returns({
             id: 'some-client-id'
         });
+        getClientIdStub = sandbox.stub().returns('some-client-id');
         removeItemStub = sandbox.stub();
         AuthRewire('http', httpStub);
         AuthRewire('handleUserConversationResponse', handleUserConversationResponseStub);
         AuthRewire('getClientInfo', getClientInfoStub);
+        AuthRewire('getClientId', getClientIdStub);
         AuthRewire('removeItem', removeItemStub);
+
+        setUserSpy = sandbox.spy(setUser);
+        AuthRewire('setUser', setUserSpy);
+
+        resetConversationSpy = sandbox.spy(resetConversation);
+        AuthRewire('resetConversation', resetConversationSpy);
+
+        disconnectFayeStub = sandbox.stub().returnsAsyncThunk();
+        AuthRewire('disconnectFaye', disconnectFayeStub);
+
+        resetUserSpy = sandbox.spy(resetUser);
+        AuthRewire('resetUser', resetUserSpy);
+
+        resetAuthSpy = sandbox.spy(resetAuth);
+        AuthRewire('resetAuth', resetAuthSpy);
+
+        setAuthSpy = sandbox.spy(setAuth);
+        AuthRewire('setAuth', setAuthSpy);
+
         mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
-            user: {
-                userId: 'some-user-id'
-            },
             auth: {
                 sessionToken: 'some-session-token'
             }
@@ -47,49 +73,157 @@ describe('Auth Actions', () => {
     });
 
     describe('login', () => {
+        let jwt;
+        let userId;
+
+        beforeEach(() => {
+            jwt = hat();
+            userId = hat();
+        });
+
         describe('user is known', () => {
             it('should call login api, remove the session token, and continue the flow', () => {
-                return mockedStore.dispatch(login()).then(() => {
-                    const {config: {appId}} = mockedStore.getState();
-                    httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
-                        userId: 'some-user-id',
-                        client: {
-                            id: 'some-client-id'
-                        },
-                        sessionToken: 'some-session-token'
+                return mockedStore.dispatch(login(userId, jwt))
+                    .then(() => {
+                        setAuthSpy.should.have.been.calledOnce;
+                        setAuthSpy.should.have.been.calledWith({
+                            jwt
+                        });
+
+                        setUserSpy.should.have.been.calledOnce;
+                        setUserSpy.should.have.been.calledWith({
+                            userId
+                        });
+
+                        resetConversationSpy.should.have.been.calledOnce;
+                        disconnectFayeStub.should.have.been.calledOnce;
+
+                        const {config: {appId}} = mockedStore.getState();
+                        httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
+                            userId,
+                            client: {
+                                id: 'some-client-id'
+                            },
+                            sessionToken: 'some-session-token'
+                        });
+                        handleUserConversationResponseStub.should.have.been.calledOnce;
+                        removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
                     });
-                    handleUserConversationResponseStub.should.have.been.calledOnce;
-                    removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
-                });
             });
         });
 
         describe('user is unknown', () => {
             beforeEach(() => {
-                httpStub.returnsAsyncThunk({
-                    value: {
-                        response: {
-                            status: 204
-                        }
-                    }
-                });
+                httpStub.returnsAsyncThunk({});
             });
+
             it('should call login api, remove the session token, and stop', () => {
-                return mockedStore.dispatch(login()).then(() => {
-                    const {config: {appId}} = mockedStore.getState();
-                    httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
-                        userId: 'some-user-id',
-                        client: {
-                            id: 'some-client-id'
-                        },
-                        sessionToken: 'some-session-token'
+                return mockedStore.dispatch(login(userId, jwt))
+                    .then(() => {
+                        setAuthSpy.should.have.been.calledOnce;
+                        setAuthSpy.should.have.been.calledWith({
+                            jwt
+                        });
+
+                        setUserSpy.should.have.been.calledOnce;
+                        setUserSpy.should.have.been.calledWith({
+                            userId
+                        });
+
+                        resetConversationSpy.should.have.been.calledOnce;
+                        disconnectFayeStub.should.have.been.calledOnce;
+
+                        const {config: {appId}} = mockedStore.getState();
+                        httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
+                            userId,
+                            client: {
+                                id: 'some-client-id'
+                            },
+                            sessionToken: 'some-session-token'
+                        });
+                        handleUserConversationResponseStub.should.not.have.been.called;
+                        removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
                     });
-                    handleUserConversationResponseStub.should.not.have.been.called;
-                    removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
-                });
             });
         });
+    });
+
+    describe('logout', () => {
+        let userId;
+        let appUserId;
+
+        beforeEach(() => {
+            userId = hat();
+            appUserId = hat();
 
 
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                user: {
+                    userId,
+                    _id: appUserId
+                }
+            }));
+        });
+
+        it('should abort if user is not logged in', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps());
+
+            return mockedStore.dispatch(logout())
+                .then(() => {
+                    httpStub.should.not.have.been.called;
+                    resetAuthSpy.should.not.have.been.called;
+                    resetUserSpy.should.not.have.been.called;
+                    resetConversationSpy.should.not.have.been.called;
+                    disconnectFayeStub.should.not.have.been.called;
+                    removeItemStub.should.not.have.been.called;
+                });
+        });
+
+        it('should log out the user if there is an appUserId', () => {
+            return mockedStore.dispatch(logout())
+                .then(() => {
+                    const {config: {appId}} = mockedStore.getState();
+
+                    httpStub.should.have.been.calledOnce;
+                    httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${appUserId}/logout`, {
+                        client: {
+                            id: 'some-client-id'
+                        }
+                    });
+
+                    resetAuthSpy.should.have.been.calledOnce;
+                    resetUserSpy.should.have.been.calledOnce;
+                    resetConversationSpy.should.have.been.calledOnce;
+                    disconnectFayeStub.should.have.been.calledOnce;
+
+                    removeItemStub.should.have.been.calledTwice;
+                    removeItemStub.should.have.been.calledWith(`${appId}.appUserId`);
+                    removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
+                });
+        });
+
+        it('should reset the store if there is no appUserId', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                user: {
+                    userId
+                }
+            }));
+
+            return mockedStore.dispatch(logout())
+                .then(() => {
+                    const {config: {appId}} = mockedStore.getState();
+
+                    httpStub.should.not.have.been.called;
+
+                    resetAuthSpy.should.have.been.calledOnce;
+                    resetUserSpy.should.have.been.calledOnce;
+                    resetConversationSpy.should.have.been.calledOnce;
+                    disconnectFayeStub.should.have.been.calledOnce;
+
+                    removeItemStub.should.have.been.calledTwice;
+                    removeItemStub.should.have.been.calledWith(`${appId}.appUserId`);
+                    removeItemStub.should.have.been.calledWith(`${appId}.sessionToken`);
+                });
+        });
     });
 });

--- a/test/specs/actions/auth.spec.js
+++ b/test/specs/actions/auth.spec.js
@@ -5,6 +5,7 @@ import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
 import { login, logout, setAuth, resetAuth, __Rewire__ as AuthRewire } from '../../../src/frame/js/actions/auth';
 import { setUser, resetUser } from '../../../src/frame/js/actions/user';
 import { resetConversation } from '../../../src/frame/js/actions/conversation';
+import { resetIntegrations } from '../../../src/frame/js/actions/integrations';
 
 describe('Auth Actions', () => {
     let mockedStore;
@@ -20,6 +21,7 @@ describe('Auth Actions', () => {
     let resetUserSpy;
     let resetAuthSpy;
     let setAuthSpy;
+    let resetIntegrationsSpy;
 
     before(() => {
         sandbox = sinon.sandbox.create();
@@ -45,6 +47,9 @@ describe('Auth Actions', () => {
 
         setUserSpy = sandbox.spy(setUser);
         AuthRewire('setUser', setUserSpy);
+
+        resetIntegrationsSpy = sandbox.spy(resetIntegrations);
+        AuthRewire('resetIntegrations', resetIntegrationsSpy);
 
         resetConversationSpy = sandbox.spy(resetConversation);
         AuthRewire('resetConversation', resetConversationSpy);
@@ -97,6 +102,7 @@ describe('Auth Actions', () => {
 
                         resetConversationSpy.should.have.been.calledOnce;
                         disconnectFayeStub.should.have.been.calledOnce;
+                        resetIntegrationsSpy.should.have.been.calledOnce;
 
                         const {config: {appId}} = mockedStore.getState();
                         httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
@@ -132,6 +138,7 @@ describe('Auth Actions', () => {
 
                         resetConversationSpy.should.have.been.calledOnce;
                         disconnectFayeStub.should.have.been.calledOnce;
+                        resetIntegrationsSpy.should.have.been.calledOnce;
 
                         const {config: {appId}} = mockedStore.getState();
                         httpStub.should.have.been.calledWith('POST', `/apps/${mockedStore.getState().config.appId}/login`, {
@@ -174,6 +181,7 @@ describe('Auth Actions', () => {
                     resetAuthSpy.should.not.have.been.called;
                     resetUserSpy.should.not.have.been.called;
                     resetConversationSpy.should.not.have.been.called;
+                    resetIntegrationsSpy.should.not.have.been.called;
                     disconnectFayeStub.should.not.have.been.called;
                     removeItemStub.should.not.have.been.called;
                 });
@@ -194,6 +202,7 @@ describe('Auth Actions', () => {
                     resetAuthSpy.should.have.been.calledOnce;
                     resetUserSpy.should.have.been.calledOnce;
                     resetConversationSpy.should.have.been.calledOnce;
+                    resetIntegrationsSpy.should.have.been.calledOnce;
                     disconnectFayeStub.should.have.been.calledOnce;
 
                     removeItemStub.should.have.been.calledTwice;
@@ -218,6 +227,7 @@ describe('Auth Actions', () => {
                     resetAuthSpy.should.have.been.calledOnce;
                     resetUserSpy.should.have.been.calledOnce;
                     resetConversationSpy.should.have.been.calledOnce;
+                    resetIntegrationsSpy.should.have.been.calledOnce;
                     disconnectFayeStub.should.have.been.calledOnce;
 
                     removeItemStub.should.have.been.calledTwice;

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -45,6 +45,7 @@ describe('Smooch', () => {
     const sandbox = sinon.sandbox.create();
 
     let loginStub;
+    let logoutStub;
     let setUserStub;
     let setAuthStub;
     let immediateUpdateStub;
@@ -86,10 +87,12 @@ describe('Smooch', () => {
         });
 
         loginStub = sandbox.stub().returnsAsyncThunk();
+        logoutStub = sandbox.stub().returnsAsyncThunk();
 
         SmoochRewire('authActions', {
             ...authActions,
             login: loginStub,
+            logout: logoutStub,
             setAuth: setAuthStub,
             resetAuth: resetAuthStub
         });
@@ -329,6 +332,7 @@ describe('Smooch', () => {
             it('should call the login action', () => {
                 return Smooch.login('some-id', 'some-jwt').then(() => {
                     loginStub.should.have.been.calledOnce;
+                    loginStub.should.have.been.calledWith('some-id', 'some-jwt');
                 });
             });
 
@@ -393,17 +397,10 @@ describe('Smooch', () => {
         });
     });
 
-    describe.skip('Logout', () => {
-        let smoochLoginStub;
-
-        beforeEach(() => {
-            smoochLoginStub = sandbox.stub().resolves();
-            SmoochRewire('login', smoochLoginStub);
-        });
-
-        it('should call login', () => {
-            Smooch.logout().then(() => {
-                smoochLoginStub.should.have.been.called;
+    describe('Logout', () => {
+        it('should call logout', () => {
+            return Smooch.logout().then(() => {
+                logoutStub.should.have.been.calledOnce;
             });
         });
     });


### PR DESCRIPTION
1. Fixed handling of `login` response, and clean up some state that
   was incorrectly preserved between users. Also fixed `login`
   incorrectly clearing the `jwt` after a successful call
2. Added full implementation of `logout`
3. Fix `startConversation` when a `userId` and `jwt` are supplied in
   `init`
4. Fix settings page when the user has not been created yet