### PR TITLE
Respect user profile config returned by the server

### DIFF
--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -2,7 +2,7 @@ import Raven from 'raven-js';
 import { batchActions } from 'redux-batched-actions';
 
 import { showErrorNotification, setShouldScrollToBottom, setFetchingMoreMessages as setFetchingMoreMessagesUi, showConnectNotification } from './app-state';
-import { setUser } from './user';
+import { setUser, immediateUpdate as immediateUpdateUser } from './user';
 import { disconnectClient, subscribe as subscribeFaye, unsetFayeSubscription } from './faye';
 
 import http from './http';
@@ -563,7 +563,8 @@ export function startConversation() {
         }
 
         return promise
-            .then((response) => dispatch(handleUserConversationResponse(response)));
+            .then((response) => dispatch(handleUserConversationResponse(response)))
+            .then(() => dispatch(immediateUpdateUser()));
     };
 }
 

--- a/src/frame/js/actions/user.js
+++ b/src/frame/js/actions/user.js
@@ -33,7 +33,7 @@ export function immediateUpdate(props) {
         }
 
         lastUpdateAttempt = Date.now();
-        console.log('Updating attempt');
+
         props = pick(Object.assign({}, pendingUserProps, props), EDITABLE_PROPERTIES);
         pendingUserProps = {};
 

--- a/test/specs/actions/user.spec.js
+++ b/test/specs/actions/user.spec.js
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import hat from 'hat';
 
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
 
@@ -10,8 +11,11 @@ describe('User Actions', () => {
     let mockedStore;
     let setUserSpy;
     let httpStub;
+    let email;
 
     beforeEach(() => {
+        email = hat();
+
         sandbox = sinon.sandbox.create();
         httpStub = sandbox.stub().returnsAsyncThunk();
         UserRewire('http', httpStub);
@@ -20,22 +24,30 @@ describe('User Actions', () => {
         UserRewire('setUser', setUserSpy);
 
         mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+            config: {
+                profile: {
+                    enabled: true,
+                    uploadInterval: 15
+                }
+            },
             user: {
                 _id: '1',
-                email: 'some@email.com'
+                email
             }
         }));
     });
 
     afterEach(() => {
         sandbox.restore();
+
+        userActions._resetState();
     });
 
     describe('immediateUpdate', () => {
         describe('is not dirty', () => {
             it('should do nothing', () => {
                 const props = {
-                    email: 'some@email.com'
+                    email
                 };
 
                 return mockedStore.dispatch(userActions.immediateUpdate(props)).then(() => {
@@ -47,34 +59,77 @@ describe('User Actions', () => {
         describe('is dirty', () => {
             it('should call api and update the store', () => {
                 const props = {
-                    email: 'other@email.com'
+                    email: hat()
                 };
 
                 const {config: {appId}, user: {_id, email}} = mockedStore.getState();
 
-                email.should.eq('some@email.com');
+                email.should.eq(email);
 
                 return mockedStore.dispatch(userActions.immediateUpdate(props)).then(() => {
                     httpStub.should.have.been.calledWith('PUT', `/apps/${appId}/appusers/${_id}`, {
-                        email: 'other@email.com'
+                        email: props.email
                     });
 
                     setUserSpy.should.have.been.calledWithMatch({
                         _id: '1',
-                        email: 'other@email.com'
+                        email: props.email
                     });
+                });
+            });
+
+            it('should not update if profile updates are disabled', () => {
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                    config: {
+                        profile: {
+                            enabled: false
+                        }
+                    },
+                    user: {
+                        _id: '1',
+                        email
+                    }
+                }));
+
+                const props = {
+                    email: hat()
+                };
+
+                return mockedStore.dispatch(userActions.immediateUpdate(props)).then(() => {
+                    httpStub.should.not.have.been.called;
                 });
             });
         });
     });
 
     // skip these untils fake timers weirdness is resolved.
-    describe.skip('update', () => {
-        let immediateUpdateStub;
+    describe('update', () => {
+        let immediateUpdateSpy;
+        let setTimeoutStub;
         beforeEach(() => {
-            sandbox.useFakeTimers();
-            immediateUpdateStub = sandbox.stub().returnsAsyncThunk();
-            UserRewire('immediateUpdate', immediateUpdateStub);
+            setTimeoutStub = sandbox.stub(global, 'setTimeout').returns(1);
+
+            immediateUpdateSpy = sandbox.spy(userActions.immediateUpdate);
+            UserRewire('immediateUpdate', immediateUpdateSpy);
+        });
+
+        it('should ignore if the user does not exist', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    profile: {
+                        enabled: true,
+                        uploadInterval: 15
+                    }
+                }
+            }));
+
+            return mockedStore.dispatch(userActions.update({
+                email: hat()
+            }))
+                .then(() => {
+                    immediateUpdateSpy.should.not.have.been.called;
+                    setTimeoutStub.should.not.have.been.called;
+                });
         });
 
         it('should call immediateUpdate', () => {
@@ -83,89 +138,88 @@ describe('User Actions', () => {
             };
 
             const promise = mockedStore.dispatch(userActions.update(props));
-            sandbox.clock.tick(1);
             return promise.then(() => {
-                immediateUpdateStub.should.have.been.calledWith(props);
+                immediateUpdateSpy.should.have.been.calledWith(props);
             });
         });
 
-        it('should be throttled for 5 sec', () => {
+        it('should be throttled', () => {
             const props = {
                 email: 'email'
             };
 
             const promise = mockedStore.dispatch(userActions.update(props));
-            sandbox.clock.tick(1);
-            return promise.then(() => {
-                immediateUpdateStub.should.have.been.calledWith(props);
-                immediateUpdateStub.reset();
-            }).then(() => {
-                const throttledPromise = mockedStore.dispatch(userActions.update(props));
-                sandbox.clock.tick(4998);
-                return throttledPromise.then(() => {
-                    immediateUpdateStub.should.not.have.been.called;
-                });
-            }).then(() => {
-                const unthrottledPromise = mockedStore.dispatch(userActions.update(props));
-                sandbox.clock.tick(1);
-                return unthrottledPromise.then(() => {
-                    immediateUpdateStub.should.have.been.calledWith(props);
-                });
-            });
+            return promise
+                .then(() => {
+                    immediateUpdateSpy.should.have.been.calledWith(props);
+                    immediateUpdateSpy.reset();
 
+                    setTimeoutStub.should.not.have.been.called;
+
+                    const throttledPromise = mockedStore.dispatch(userActions.update(props));
+
+                    // timer should be started
+                    setTimeoutStub.should.have.been.calledOnce;
+
+                    immediateUpdateSpy.should.not.have.been.called;
+
+                    const unthrottledPromise = mockedStore.dispatch(userActions.update(props));
+
+                    // it should reuse the same timer
+                    setTimeoutStub.should.have.been.calledOnce;
+
+                    // Fulfill the timer
+                    setTimeoutStub.firstCall.args[0]();
+
+                    return Promise.all([unthrottledPromise, throttledPromise]);
+                })
+                .then(() => {
+                    immediateUpdateSpy.should.have.been.calledOnce;
+                    immediateUpdateSpy.should.have.been.calledWith(props);
+                });
         });
 
-
-        it('should merge props when throttling and reset for the next call', () => {
+        it('should merge props when throttling', () => {
             const promise = mockedStore.dispatch(userActions.update({
                 email: 'this@email.com'
             }));
 
-            // needs to tick one for the internal promise mechanism to work
-            sandbox.clock.tick(1);
-            return promise.then(() => {
-                immediateUpdateStub.should.have.been.calledWith({
-                    email: 'this@email.com'
-                });
-            }).then(() => {
-                const throttledPromise = mockedStore.dispatch(userActions.update({
-                    givenName: 'Example'
-                }));
+            return promise
+                .then(() => {
+                    immediateUpdateSpy.should.have.been.calledWith({
+                        email: 'this@email.com'
+                    });
+                    immediateUpdateSpy.reset();
+                    setTimeoutStub.should.not.have.been.called;
 
-                // move just under 5000 ms
-                sandbox.clock.tick(4998);
+                    const throttledPromise = mockedStore.dispatch(userActions.update({
+                        givenName: 'Example'
+                    }));
 
-                return throttledPromise.then(() => {
-                    immediateUpdateStub.should.not.have.been.called;
-                });
-            }).then(() => {
-                const unthrottledPromise = mockedStore.dispatch(userActions.update({
-                    email: 'another@email.com'
-                }));
+                    // timer should be started
+                    setTimeoutStub.should.have.been.calledOnce;
 
-                // move up to 5000
-                sandbox.clock.tick(1);
+                    immediateUpdateSpy.should.not.have.been.called;
 
-                return unthrottledPromise.then(() => {
-                    immediateUpdateStub.should.have.been.calledWith({
+                    const unthrottledPromise = mockedStore.dispatch(userActions.update({
+                        email: 'another@email.com'
+                    }));
+
+                    // it should reuse the same timer
+                    setTimeoutStub.should.have.been.calledOnce;
+
+                    // Fulfill the timer
+                    setTimeoutStub.firstCall.args[0]();
+
+                    return Promise.all([unthrottledPromise, throttledPromise]);
+                })
+                .then(() => {
+                    immediateUpdateSpy.should.have.been.calledOnce;
+                    immediateUpdateSpy.should.have.been.calledWith({
                         givenName: 'Example',
                         email: 'another@email.com'
                     });
                 });
-            }).then(() => {
-                // move to an unthrottled timeframe
-                sandbox.clock.tick(20000);
-
-                const unthrottledPromise = mockedStore.dispatch(userActions.update({
-                    email: 'yetanother@email.com'
-                }));
-                sandbox.clock.tick(1);
-                return unthrottledPromise.then(() => {
-                    immediateUpdateStub.should.have.been.calledWith({
-                        email: 'yetanother@email.com'
-                    });
-                });
-            });
         });
     });
 });


### PR DESCRIPTION
1. Use `config.profile.uploadInterval` instead of hardcoded value for
   user props throttling
2. Do not upload user props if `config.profile.enabled` is false
3. Wait to upload user props if the user has not been created yet
4. Fix `isDirty` check being dirty too often
5. Upload any pending user props after a user is created
6. Fix `update` tests to mock `setTimeout` instead of relying on
   broken sinon timers