### PR TITLE
Enable channel linking for users that have not started a convo

### DIFF
--- a/src/frame/js/actions/app-state.js
+++ b/src/frame/js/actions/app-state.js
@@ -74,11 +74,8 @@ export function closeWidget() {
 }
 
 export function showSettings() {
-    return (dispatch) => {
-        dispatch({
-            type: SHOW_SETTINGS
-        });
-        return dispatch(subscribeFaye());
+    return {
+        type: SHOW_SETTINGS
     };
 }
 
@@ -189,8 +186,7 @@ export function showChannelPage(channelType) {
                 channelType
             });
 
-            return dispatch(subscribeFaye())
-                .then(() => dispatch(channelDetails.onChannelPage()));
+            return dispatch(channelDetails.onChannelPage());
         }
     };
 }

--- a/src/frame/js/actions/faye.js
+++ b/src/frame/js/actions/faye.js
@@ -221,13 +221,17 @@ function handleLinkEvents(events) {
 
 export function subscribe() {
     return (dispatch, getState) => {
-        const client = dispatch(getClient());
         const {config: {appId}, user: {_id}, faye: {subscription: existingSubscription}} = getState();
+
+        if (!_id) {
+            return Promise.resolve();
+        }
 
         if (existingSubscription) {
             return existingSubscription;
         }
 
+        const client = dispatch(getClient());
         const subscription = client.subscribe(`/sdk/apps/${appId}/appusers/${_id}`, function({events}) {
             const messageEvents = events.filter(({type}) => type === 'message');
             const activityEvents = events.filter(({type}) => type === 'activity');

--- a/src/frame/js/components/Settings.jsx
+++ b/src/frame/js/components/Settings.jsx
@@ -20,10 +20,6 @@ export class SettingsComponent extends Component {
     render() {
         const {appChannels, user, notificationSettingsChannelsTitleText, notificationSettingsChannelsDescriptionText} = this.props;
 
-        if (!user._id) {
-            return null;
-        }
-
         let channels = getAppChannelDetails(appChannels);
         channels.sort(({channel}) => {
             // List the linked channels first

--- a/src/frame/js/components/Widget.jsx
+++ b/src/frame/js/components/Widget.jsx
@@ -23,7 +23,6 @@ import { disableAnimation } from '../actions/app-state';
 export class WidgetComponent extends Component {
     static propTypes = {
         dispatch: PropTypes.func.isRequired,
-        smoochId: PropTypes.string,
         config: PropTypes.object.isRequired,
         widgetSize: PropTypes.string.isRequired,
         appState: PropTypes.object.isRequired
@@ -60,14 +59,14 @@ export class WidgetComponent extends Component {
     };
 
     render() {
-        const {appState, config, smoochId, widgetSize} = this.props;
+        const {appState, config, widgetSize} = this.props;
         const {displayStyle, isBrandColorDark, isAccentColorDark, isLinkColorDark} = config.style;
 
         const settingsComponent = appState.settingsVisible ? <Settings /> : null;
 
         // if no user set in store or the app has no channels,
         // no need to render the channel page manager
-        const channelsComponent = smoochId && hasChannels(config) ? <Channel /> : null;
+        const channelsComponent = hasChannels(config) ? <Channel /> : null;
 
         const footer = appState.settingsVisible ? null : <ChatInput ref={ (c) => this._input = c } />;
 
@@ -156,7 +155,6 @@ export default connect(({appState: {settingsVisible, widgetState, errorNotificat
             showAnimation
         },
         config,
-        widgetSize,
-        smoochId: user._id
+        widgetSize
     };
 })(WidgetComponent);

--- a/src/frame/js/components/channels/Channel.jsx
+++ b/src/frame/js/components/channels/Channel.jsx
@@ -18,10 +18,6 @@ export class ChannelComponent extends Component {
     render() {
         const {appChannels, visibleChannelType, smoochId, clients, pendingClients, channelStates} = this.props;
 
-        if (!smoochId) {
-            return null;
-        }
-
         const channelPages = getAppChannelDetails(appChannels).map(({channel, details}) => {
             const client = clients.find((client) => client.platform === channel.type);
             const pendingClient = pendingClients.find((client) => client.platform === channel.type);

--- a/src/frame/js/utils/user.js
+++ b/src/frame/js/utils/user.js
@@ -1,11 +1,11 @@
 import { CHANNEL_DETAILS } from '../constants/channels';
 import { getIntegration } from './app';
 
-export function isChannelLinked(clients, channelType) {
+export function isChannelLinked(clients = [], channelType) {
     return !!clients.find((client) => client.platform === channelType);
 }
 
-export function getDisplayName(clients, channelType) {
+export function getDisplayName(clients = [], channelType) {
     const client = clients.find((client) => client.platform === channelType);
     return client && client.displayName;
 }
@@ -22,7 +22,7 @@ export function getLinkableChannels(appChannels) {
         });
 }
 
-export function hasLinkableChannels(appChannels, clients) {
+export function hasLinkableChannels(appChannels, clients = []) {
     return getLinkableChannels(appChannels)
         .some((channelType) => {
             // a channel is not considered as linkable if it's already linked

--- a/test/specs/actions/integrations.spec.js
+++ b/test/specs/actions/integrations.spec.js
@@ -5,17 +5,23 @@ import { createMock as createThrottleMock } from '../../mocks/throttle';
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
 
 import * as integrationsActions from '../../../src/frame/js/actions/integrations';
-import { __Rewire__ as IntegrationsRewire } from '../../../src/frame/js/actions/integrations';
+import { __Rewire__ as IntegrationsRewire, updateSMSAttributes, setTransferRequestCode, setWeChatQRCode, setViberQRCode } from '../../../src/frame/js/actions/integrations';
 import { updateUser } from '../../../src/frame/js/actions/user';
-
 
 describe('Integrations Actions', () => {
     let sandbox;
 
+    let appUserId;
     let httpStub;
+    let startConversationStub;
     let mockedStore;
     let updateUserSpy;
     let handleConversationUpdatedStub;
+    let subscribeFayeStub;
+    let updateSMSAttributesSpy;
+    let setTransferRequestCodeSpy;
+    let setWeChatQRCodeSpy;
+    let setViberQRCodeSpy;
 
     before(() => {
         sandbox = sinon.sandbox.create();
@@ -24,62 +30,171 @@ describe('Integrations Actions', () => {
     beforeEach(() => {
         // Disable throttling for unit tests
         IntegrationsRewire('Throttle', createThrottleMock(sandbox));
+
         httpStub = sandbox.stub().returnsAsyncThunk();
         IntegrationsRewire('http', httpStub);
+
+        startConversationStub = sandbox.stub().returnsAsyncThunk();
+        IntegrationsRewire('startConversation', startConversationStub);
+
         updateUserSpy = sandbox.spy(updateUser);
         IntegrationsRewire('updateUser', updateUserSpy);
+
+        updateSMSAttributesSpy = sandbox.spy(updateSMSAttributes);
+        IntegrationsRewire('updateSMSAttributes', updateSMSAttributesSpy);
+
+        setTransferRequestCodeSpy = sandbox.spy(setTransferRequestCode);
+        IntegrationsRewire('setTransferRequestCode', setTransferRequestCodeSpy);
+
+        setWeChatQRCodeSpy = sandbox.spy(setWeChatQRCode);
+        IntegrationsRewire('setWeChatQRCode', setWeChatQRCodeSpy);
+
+        setViberQRCodeSpy = sandbox.spy(setViberQRCode);
+        IntegrationsRewire('setViberQRCode', setViberQRCodeSpy);
+
         handleConversationUpdatedStub = sandbox.stub().returnsAsyncThunk();
         IntegrationsRewire('handleConversationUpdated', handleConversationUpdatedStub);
 
+        subscribeFayeStub = sandbox.stub().returnsAsyncThunk();
+        IntegrationsRewire('subscribeFaye', subscribeFayeStub);
+
+        appUserId = hat();
         mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
             user: {
-                _id: '1'
+                _id: appUserId
             }
         }));
-
     });
 
     afterEach(() => {
         sandbox.restore();
     });
 
+    function mockStartConversation(appUserId, conversationId) {
+        startConversationStub.callsFake(() => {
+            mockedStore.getState().user._id = appUserId;
+            mockedStore.getState().conversation._id = conversationId;
+
+            return () => Promise.resolve();
+        });
+    }
 
     describe('linkSMSChannel', () => {
         let conversationId;
+        let createdClient;
 
         beforeEach(() => {
-            httpStub.returnsAsyncThunk({
-                value: {
-                    client: {}
-                }
-            });
-
             conversationId = hat();
-            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
-                conversation: {
-                    _id: conversationId
-                }
-            }));
+            createdClient = {
+                id: hat()
+            };
         });
 
-        it('should set the twilio integration to pending state', () => {
-            const {config: {appId}, user: {_id}} = mockedStore.getState();
-            return mockedStore.dispatch(integrationsActions.linkSMSChannel({
-                type: 'twilio',
-                phoneNumber: '+0123456789'
-            })).then(() => {
-                httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${_id}/clients`, {
-                    criteria: {
-                        type: 'twilio',
-                        phoneNumber: '+0123456789'
-                    },
-                    confirmation: {
-                        type: 'prompt'
-                    },
-                    target: {
-                        conversationId
+        describe('when the user exists', () => {
+            beforeEach(() => {
+                httpStub.returnsAsyncThunk({
+                    value: {
+                        client: createdClient
                     }
                 });
+
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                    user: {
+                        _id: appUserId
+                    },
+                    conversation: {
+                        _id: conversationId
+                    }
+                }));
+            });
+
+            it('should set the twilio integration to pending state', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.linkSMSChannel({
+                    type: 'twilio',
+                    phoneNumber: '+0123456789'
+                }))
+                    .then(() => {
+                        httpStub.should.have.been.calledOnce;
+                        httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${appUserId}/clients`, {
+                            criteria: {
+                                type: 'twilio',
+                                phoneNumber: '+0123456789'
+                            },
+                            confirmation: {
+                                type: 'prompt'
+                            },
+                            target: {
+                                conversationId
+                            }
+                        });
+
+                        updateUserSpy.should.have.been.calledOnce;
+                        updateUserSpy.should.have.been.calledWith({
+                            pendingClients: [createdClient]
+                        });
+
+                        updateSMSAttributesSpy.should.have.been.calledOnce;
+                        updateSMSAttributesSpy.should.have.been.calledWith({
+                            linkState: 'pending'
+                        }, 'twilio');
+
+                        subscribeFayeStub.should.have.been.calledOnce;
+                        startConversationStub.should.not.have.been.called;
+                    });
+            });
+        });
+
+        describe('when the user does not exist', () => {
+            beforeEach(() => {
+                mockStartConversation(appUserId, conversationId);
+                httpStub.returnsAsyncThunk({
+                    value: {
+                        client: createdClient
+                    }
+                });
+
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({}));
+            });
+
+
+            it('should create the user and link twilio', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.linkSMSChannel({
+                    type: 'twilio',
+                    phoneNumber: '+0123456789'
+                }))
+                    .then(() => {
+                        startConversationStub.should.have.been.calledOnce;
+
+                        httpStub.should.have.been.calledOnce;
+                        httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${appUserId}/clients`, {
+                            criteria: {
+                                type: 'twilio',
+                                phoneNumber: '+0123456789'
+                            },
+                            confirmation: {
+                                type: 'prompt'
+                            },
+                            target: {
+                                conversationId
+                            }
+                        });
+
+                        updateUserSpy.should.have.been.calledOnce;
+                        updateUserSpy.should.have.been.calledWith({
+                            pendingClients: [createdClient]
+                        });
+
+                        updateSMSAttributesSpy.should.have.been.calledOnce;
+                        updateSMSAttributesSpy.should.have.been.calledWith({
+                            linkState: 'pending'
+                        }, 'twilio');
+
+                        subscribeFayeStub.should.not.have.been.called;
+                    });
             });
         });
     });
@@ -133,15 +248,22 @@ describe('Integrations Actions', () => {
     });
 
     describe('fetchTransferRequestCode', () => {
+        let integrations;
+        let appUserId;
+
         beforeEach(() => {
+            integrations = [{
+                type: 'messenger',
+                _id: 'messenger-integration'
+            }];
+            appUserId = hat();
+
             mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
                 config: {
-                    integrations: [
-                        {
-                            type: 'messenger',
-                            _id: 'messenger-integration'
-                        }
-                    ]
+                    integrations
+                },
+                user: {
+                    _id: appUserId
                 }
             }));
 
@@ -154,14 +276,300 @@ describe('Integrations Actions', () => {
             });
         });
 
-        it('should call the transferrequest API', () => {
-            const channel = 'messenger';
-            const {config: {appId}, user: {_id}} = mockedStore.getState();
-            return mockedStore.dispatch(integrationsActions.fetchTransferRequestCode(channel)).then(() => {
-                httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${_id}/transferrequest`, {
-                    type: channel,
-                    integrationId: 'messenger-integration'
+        it('should abort if the integration doesnt exist', () => {
+            const channel = hat();
+
+            return mockedStore.dispatch(integrationsActions.fetchTransferRequestCode(channel))
+                .then(() => {
+                    subscribeFayeStub.should.not.have.been.called;
+                    httpStub.should.not.have.been.called;
+                    setTransferRequestCodeSpy.should.not.have.been.called;
                 });
+        });
+
+        describe('when the user exists', () => {
+            it('should call the transferrequest API', () => {
+                const channel = 'messenger';
+                const {config: {appId}} = mockedStore.getState();
+                return mockedStore.dispatch(integrationsActions.fetchTransferRequestCode(channel))
+                    .then(() => {
+                        subscribeFayeStub.should.have.been.calledOnce;
+                        startConversationStub.should.not.have.been.called;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/transferrequest`, {
+                            type: channel,
+                            integrationId: 'messenger-integration'
+                        });
+
+                        setTransferRequestCodeSpy.should.have.been.calledOnce;
+                        setTransferRequestCodeSpy.should.have.been.calledWith(channel, '1234');
+                    });
+            });
+        });
+
+        describe('when the user does not exist', () => {
+            beforeEach(() => {
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                    config: {
+                        integrations
+                    }
+                }));
+
+                mockStartConversation(appUserId, hat());
+            });
+
+            it('should call the transferrequest API', () => {
+                const channel = 'messenger';
+                const {config: {appId}} = mockedStore.getState();
+                return mockedStore.dispatch(integrationsActions.fetchTransferRequestCode(channel))
+                    .then(() => {
+                        startConversationStub.should.have.been.calledOnce;
+                        subscribeFayeStub.should.not.have.been.calledOnce;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/transferrequest`, {
+                            type: channel,
+                            integrationId: 'messenger-integration'
+                        });
+
+                        setTransferRequestCodeSpy.should.have.been.calledOnce;
+                        setTransferRequestCodeSpy.should.have.been.calledWith(channel, '1234');
+                    });
+            });
+        });
+    });
+
+    describe('fetchWeChatQRCode', () => {
+        let integrations;
+        let appUserId;
+        let url;
+
+        beforeEach(() => {
+            integrations = [{
+                type: 'wechat',
+                _id: hat()
+            }];
+            appUserId = hat();
+            url = hat();
+
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations
+                },
+                user: {
+                    _id: appUserId
+                },
+                integrations: {
+                    wechat: {}
+                }
+            }));
+
+            httpStub.returnsAsyncThunk({
+                value: {
+                    url
+                }
+            });
+        });
+
+        it('should abort if the integration doesnt exist', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations: []
+                },
+                integrations: {
+                    wechat: {}
+                }
+            }));
+
+            return mockedStore.dispatch(integrationsActions.fetchWeChatQRCode())
+                .then(() => {
+                    subscribeFayeStub.should.not.have.been.called;
+                    httpStub.should.not.have.been.called;
+                    setWeChatQRCodeSpy.should.not.have.been.called;
+                });
+        });
+
+        it('should abort if a qr code has been fetched', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations
+                },
+                integrations: {
+                    wechat: {
+                        qrCode: hat()
+                    }
+                }
+            }));
+
+            return mockedStore.dispatch(integrationsActions.fetchWeChatQRCode())
+                .then(() => {
+                    subscribeFayeStub.should.not.have.been.called;
+                    httpStub.should.not.have.been.called;
+                    setWeChatQRCodeSpy.should.not.have.been.called;
+                });
+        });
+
+        describe('when the user exists', () => {
+            it('should call the qr code API', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.fetchWeChatQRCode())
+                    .then(() => {
+                        subscribeFayeStub.should.have.been.calledOnce;
+                        startConversationStub.should.not.have.been.called;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);
+
+                        setWeChatQRCodeSpy.should.have.been.calledOnce;
+                        setWeChatQRCodeSpy.should.have.been.calledWith(url);
+                    });
+            });
+        });
+
+        describe('when the user does not exist', () => {
+            beforeEach(() => {
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                    config: {
+                        integrations
+                    },
+                    integrations: {
+                        wechat: {}
+                    }
+                }));
+
+                mockStartConversation(appUserId, hat());
+            });
+
+            it('should call the qr code API', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.fetchWeChatQRCode())
+                    .then(() => {
+                        startConversationStub.should.have.been.calledOnce;
+                        subscribeFayeStub.should.not.have.been.calledOnce;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);
+
+                        setWeChatQRCodeSpy.should.have.been.calledOnce;
+                        setWeChatQRCodeSpy.should.have.been.calledWith(url);
+                    });
+            });
+        });
+    });
+
+    describe('fetchViberQRCode', () => {
+        let integrations;
+        let appUserId;
+        let url;
+
+        beforeEach(() => {
+            integrations = [{
+                type: 'viber',
+                _id: hat()
+            }];
+            appUserId = hat();
+            url = hat();
+
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations
+                },
+                user: {
+                    _id: appUserId
+                },
+                integrations: {
+                    viber: {}
+                }
+            }));
+
+            httpStub.returnsAsyncThunk({
+                value: {
+                    url
+                }
+            });
+        });
+
+        it('should abort if the integration doesnt exist', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations: []
+                },
+                integrations: {
+                    viber: {}
+                }
+            }));
+
+            return mockedStore.dispatch(integrationsActions.fetchViberQRCode())
+                .then(() => {
+                    subscribeFayeStub.should.not.have.been.called;
+                    httpStub.should.not.have.been.called;
+                    setViberQRCodeSpy.should.not.have.been.called;
+                });
+        });
+
+        it('should abort if a qr code has been fetched', () => {
+            mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                config: {
+                    integrations
+                },
+                integrations: {
+                    viber: {
+                        qrCode: hat()
+                    }
+                }
+            }));
+
+            return mockedStore.dispatch(integrationsActions.fetchViberQRCode())
+                .then(() => {
+                    subscribeFayeStub.should.not.have.been.called;
+                    httpStub.should.not.have.been.called;
+                    setViberQRCodeSpy.should.not.have.been.called;
+                });
+        });
+
+        describe('when the user exists', () => {
+            it('should call the qr code API', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.fetchViberQRCode())
+                    .then(() => {
+                        subscribeFayeStub.should.have.been.calledOnce;
+                        startConversationStub.should.not.have.been.called;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);
+
+                        setViberQRCodeSpy.should.have.been.calledOnce;
+                        setViberQRCodeSpy.should.have.been.calledWith(url);
+                    });
+            });
+        });
+
+        describe('when the user does not exist', () => {
+            beforeEach(() => {
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
+                    config: {
+                        integrations
+                    },
+                    integrations: {
+                        viber: {}
+                    }
+                }));
+
+                mockStartConversation(appUserId, hat());
+            });
+
+            it('should call the qr code API', () => {
+                const {config: {appId}} = mockedStore.getState();
+
+                return mockedStore.dispatch(integrationsActions.fetchViberQRCode())
+                    .then(() => {
+                        startConversationStub.should.have.been.calledOnce;
+                        subscribeFayeStub.should.not.have.been.calledOnce;
+
+                        httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);
+
+                        setViberQRCodeSpy.should.have.been.calledOnce;
+                        setViberQRCodeSpy.should.have.been.calledWith(url);
+                    });
             });
         });
     });

--- a/test/specs/components/Settings.spec.jsx
+++ b/test/specs/components/Settings.spec.jsx
@@ -1,5 +1,4 @@
 import sinon from 'sinon';
-import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
 
 import NotificationChannelItem from '../../../src/frame/js/components/NotificationChannelItem';
@@ -64,15 +63,7 @@ describe('Settings', () => {
             }
         ]);
 
-        const storeProps = {
-            ...defaultStoreProps,
-            user: {
-                _id: 1230912,
-                clients: []
-            }
-        };
-
-        mockedStore = createMockedStore(sandbox, storeProps);
+        mockedStore = createMockedStore(sandbox, defaultStoreProps);
 
         component = wrapComponentWithStore(Settings, null, mockedStore);
     });
@@ -93,18 +84,5 @@ describe('Settings', () => {
     it('should set channel description text', () => {
         const description = TestUtils.scryRenderedDOMComponentsWithClass(component, 'settings-description')[0];
         description.textContent.should.eq(mockedStore.getState().ui.text.notificationSettingsChannelsDescription);
-    });
-
-    describe('No user id', () => {
-        beforeEach(() => {
-            mockedStore = createMockedStore(sandbox, defaultStoreProps);
-
-            component = wrapComponentWithStore(Settings, null, mockedStore);
-        });
-
-        it('should not render', () => {
-            const componentNode = ReactDOM.findDOMNode(component);
-            expect(componentNode).to.be.null;
-        });
     });
 });

--- a/test/specs/components/channels/Channel.spec.jsx
+++ b/test/specs/components/channels/Channel.spec.jsx
@@ -34,14 +34,6 @@ describe('Channel Component', () => {
         sandbox.restore();
     });
 
-    it('should render nothing if no smoochId', () => {
-        const store = createMockedStore(sandbox, generateBaseStoreProps({
-            user: {}
-        }));
-        const component = wrapComponentWithStore(Channel, null, store);
-        TestUtils.scryRenderedDOMComponentsWithClass(component, 'channel-pages-container').length.should.be.eq(0);
-    });
-
     it('should render container without children if no channels', () => {
         const store = createMockedStore(sandbox, generateBaseStoreProps({
             user: {


### PR DESCRIPTION
Users that have not been created yet on the server should still be
allowed to link channels. This change forces user creation when a
linking action is initiated. Linking actions include generating a
transfer request, requesting a QR code for WeChat or Viber, or calling
the `POST /clients` to start SMS linking.

If a user has already been created, but the faye connection does not
exist for some reason, we instead force a connection to faye when a
linking action is initiated.

This change also modifies a few views that were refusing to render
themselves when the smooch user id did not exist, to make them
compatible with a non-existing user.