### PR TITLE
Fix link events with user switching

### DIFF
--- a/src/frame/js/actions/user.js
+++ b/src/frame/js/actions/user.js
@@ -99,14 +99,6 @@ export function update(props) {
     };
 }
 
-export function _resetState() {
-    clearTimeout(pendingTimeout);
-    pendingTimeout = null;
-    pendingResolve = null;
-    pendingUserProps = {};
-    lastUpdateAttempt = undefined;
-}
-
 export function setUser(props) {
     return {
         type: SET_USER,

--- a/test/specs/actions/user.spec.js
+++ b/test/specs/actions/user.spec.js
@@ -4,7 +4,7 @@ import hat from 'hat';
 import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
 
 import * as userActions from '../../../src/frame/js/actions/user';
-import { __Rewire__ as UserRewire } from '../../../src/frame/js/actions/user';
+import { __Rewire__ as UserRewire, __RewireAPI__ as UserRewireAPI } from '../../../src/frame/js/actions/user';
 
 describe('User Actions', () => {
     let sandbox;
@@ -35,12 +35,16 @@ describe('User Actions', () => {
                 email
             }
         }));
+
+        clearTimeout(UserRewireAPI.__get__('pendingTimeout'));
+        UserRewireAPI.__set__('pendingTimeout', null);
+        UserRewireAPI.__set__('pendingResolve', null);
+        UserRewireAPI.__set__('pendingUserProps', {});
+        UserRewireAPI.__set__('lastUpdateAttempt', undefined);
     });
 
     afterEach(() => {
         sandbox.restore();
-
-        userActions._resetState();
     });
 
     describe('immediateUpdate', () => {
@@ -102,7 +106,6 @@ describe('User Actions', () => {
         });
     });
 
-    // skip these untils fake timers weirdness is resolved.
     describe('update', () => {
         let immediateUpdateSpy;
         let setTimeoutStub;


### PR DESCRIPTION
While addressing code review comments from #585 and #587 I realized
that link events were handled incorrectly when the user changed. The
`login` event now expects a `userId` and `jwt` as params, which we
weren't passing. Also, we were still connected to the the faye channel
for the old discarded user.