### PR TITLE
Add support for vendor id

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     },
     "globals": {
         "VERSION": true,
+        "VENDOR_ID": true,
         "FRAME_JS_URL": true,
         "FRAME_CSS_URL": true,
         "SENTRY_DSN": true,

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -29,6 +29,10 @@ module.exports = function(options) {
     const config = require('./config/default/config.json');
     const {buildType} = options;
 
+    // set VENDOR_ID env var or pass it in the options
+    // before calling webpack to set the vendor id
+    const vendorId = process.env.VENDOR_ID || options.vendorId || 'smooch';
+
     try {
         Object.assign(config, require('./config/config.json'));
     }
@@ -206,6 +210,7 @@ module.exports = function(options) {
     const plugins = [
         new webpack.DefinePlugin({
             VERSION: `'${VERSION}'`,
+            VENDOR_ID: `'${vendorId}'`,
             FRAME_JS_URL: `'${publicPath}${frameJsFilename}'`,
             FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`,
             SENTRY_DSN: options.sentryDsn ? `'${options.sentryDsn}'` : 'undefined'

--- a/src/frame/js/actions/http.js
+++ b/src/frame/js/actions/http.js
@@ -59,7 +59,7 @@ export default function http(method, url, data, extraHeaders = {}, baseUrl) {
         const headers = {
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'x-smooch-sdk': `web/${VERSION}`,
+            'x-smooch-sdk': `web/${VENDOR_ID}/${VERSION}`,
             'x-smooch-clientid': getClientId(config.appId),
             'x-smooch-appid': config.appId,
             ...extraHeaders

--- a/test/specs/actions/http.spec.js
+++ b/test/specs/actions/http.spec.js
@@ -25,7 +25,7 @@ function generateExpectation(method, url, data, headers, useJwt, useSessionToken
         headers: Object.assign({
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'x-smooch-sdk': `web/${VERSION}`
+            'x-smooch-sdk': `web/${VENDOR_ID}/${VERSION}`
         }, headers)
     };
 


### PR DESCRIPTION
I added support for vendor id in the webpack config to make it convenient once we tackle white labelling.