### PR TITLE
Use promise rejections instead of throwing

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ['mocha', 'sinon-chai'],
+        frameworks: ['mocha', 'chai-as-promised', 'sinon-chai'],
         // list of files / patterns to load in the browser
         files: [
             'test/index.js'

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "json-loader": "0.5.4",
     "karma": "0.13.22",
     "karma-chai": "0.1.0",
+    "karma-chai-as-promised": "0.1.2",
     "karma-chrome-launcher": "0.1.12",
     "karma-junit-reporter": "1.2.0",
     "karma-mocha": "0.1.10",

--- a/src/frame/js/smooch.jsx
+++ b/src/frame/js/smooch.jsx
@@ -110,11 +110,11 @@ export function init(props = {}) {
     const {appState: {isInitialized}} = store.getState();
 
     if (isInitialized) {
-        throw new Error('Web Messenger is already initialized. Call `destroy()` first before calling `init()` again.');
+        return Promise.reject(new Error('Web Messenger is already initialized. Call `destroy()` first before calling `init()` again.'));
     }
 
     if (!props.appId) {
-        throw new Error('Must provide an appId');
+        return Promise.reject(new Error('Must provide an appId'));
     }
 
     lastTriggeredMessageTimestamp = 0;
@@ -220,7 +220,7 @@ export function init(props = {}) {
 
 export function login(userId, jwt) {
     if (!userId || !jwt) {
-        throw new Error('Must provide a userId and a jwt to log in.');
+        return Promise.reject(new Error('Must provide a userId and a jwt to log in.'));
     }
 
     return store.dispatch(authActions.login(userId, jwt));

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -283,13 +283,13 @@ describe('Smooch', () => {
                         });
 
                         it('should reject', () => {
-                            Smooch.init(props).should.be.rejectedWith(Error, /already initialized/);
+                            return Smooch.init(props).should.be.rejectedWith(Error, /already initialized/);
                         });
                     });
 
                     describe('without appId', () => {
                         it('should throw', () => {
-                            Smooch.init().should.be.rejectedWith(Error, /provide an appId/);
+                            return Smooch.init().should.be.rejectedWith(Error, /provide an appId/);
                         });
                     });
 
@@ -335,9 +335,11 @@ describe('Smooch', () => {
             });
 
             it('should throw if missing props', () => {
-                Smooch.login('some-id').should.be.rejectedWith(Error, /provide a userId and a jwt/)
-                Smooch.login(undefined, 'some-jwt').should.be.rejectedWith(Error, /provide a userId and a jwt/);
-                Smooch.login().should.be.rejectedWith(Error, /provide a userId and a jwt/);
+                return Promise.all([
+                    Smooch.login('some-id').should.be.rejectedWith(Error, /provide a userId and a jwt/),
+                    Smooch.login(undefined, 'some-jwt').should.be.rejectedWith(Error, /provide a userId and a jwt/),
+                    Smooch.login().should.be.rejectedWith(Error, /provide a userId and a jwt/)
+                ]);
             });
         });
     });

--- a/test/specs/smooch.spec.js
+++ b/test/specs/smooch.spec.js
@@ -282,16 +282,14 @@ describe('Smooch', () => {
                             }));
                         });
 
-                        it('should throw', () => {
-                            (function() {
-                                Smooch.init(props);
-                            }).should.throw(/already initialized/);
+                        it('should reject', () => {
+                            Smooch.init(props).should.be.rejectedWith(Error, /already initialized/);
                         });
                     });
 
                     describe('without appId', () => {
                         it('should throw', () => {
-                            Smooch.init.should.throw(/provide an appId/);
+                            Smooch.init().should.be.rejectedWith(Error, /provide an appId/);
                         });
                     });
 
@@ -337,9 +335,9 @@ describe('Smooch', () => {
             });
 
             it('should throw if missing props', () => {
-                expect(() => Smooch.login('some-id')).to.throw;
-                expect(() => Smooch.login(undefined, 'some-jwt')).to.throw;
-                expect(() => Smooch.login()).to.throw;
+                Smooch.login('some-id').should.be.rejectedWith(Error, /provide a userId and a jwt/)
+                Smooch.login(undefined, 'some-jwt').should.be.rejectedWith(Error, /provide a userId and a jwt/);
+                Smooch.login().should.be.rejectedWith(Error, /provide a userId and a jwt/);
             });
         });
     });


### PR DESCRIPTION
While I was preparing the testing phrase, I realize how the expectations for the public function were screwed up. If you were calling `init` with bad props, it would throw. If props were good but auth was bad (bad appId for instance), it would return a rejected promise. 

I made everything return a rejected promise if that function was meant to return a promise when it's working alright. The current version works like that anyway.