### PR TITLE
Branding changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,7 @@
         "FRAME_JS_URL": true,
         "FRAME_CSS_URL": true,
         "SENTRY_DSN": true,
+        "IS_BRANDED": true,
         "__rewire_reset_all__": true
     },
     "plugins": [

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -31,6 +31,7 @@ module.exports = function(options) {
 
     // set branding variables in the env vars or pass them via the options
     const vendorId = process.env.VENDOR_ID || options.vendorId || PACKAGE_NAME;
+    const isBranded = vendorId !== PACKAGE_NAME;
     const licenseContent = process.env.LICENSE || options.license || LICENSE;
     const providedPublicPath = process.env.PUBLIC_PATH || options.publicPath;
 
@@ -214,7 +215,8 @@ module.exports = function(options) {
             VENDOR_ID: `'${vendorId}'`,
             FRAME_JS_URL: `'${publicPath}${frameJsFilename}'`,
             FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`,
-            SENTRY_DSN: options.sentryDsn ? `'${options.sentryDsn}'` : 'undefined'
+            SENTRY_DSN: options.sentryDsn ? `'${options.sentryDsn}'` : 'undefined',
+            IS_BRANDED: `${isBranded}`
         })
     ];
 

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -34,6 +34,7 @@ module.exports = function(options) {
     const isBranded = vendorId !== PACKAGE_NAME;
     const licenseContent = process.env.LICENSE || options.license || LICENSE;
     const providedPublicPath = process.env.PUBLIC_PATH || options.publicPath;
+    const version = process.env.VERSION || VERSION;
 
     try {
         Object.assign(config, require('./config/config.json'));
@@ -169,7 +170,7 @@ module.exports = function(options) {
     // Only need to append the version if we're building the host lib or the frame lib
     // in prevision of a release.
     const baseFilename = ['host', 'frame'].includes(buildType) ?
-        `[name].${VERSION}` :
+        `[name].${version}` :
         '[name]';
 
     // Only use .min.js if we ask for minification
@@ -202,8 +203,8 @@ module.exports = function(options) {
     if (['host', 'npm'].includes(buildType)) {
         // in this case, it's referencing an already built frame lib
         // and it's mostly likely minified already.
-        frameJsFilename = `frame.${VERSION}.min.js`;
-        frameCssFilename = `frame.${VERSION}.css`;
+        frameJsFilename = `frame.${version}.min.js`;
+        frameCssFilename = `frame.${version}.css`;
     } else {
         frameJsFilename = 'frame.js';
         frameCssFilename = 'frame.css';
@@ -211,7 +212,7 @@ module.exports = function(options) {
 
     const plugins = [
         new webpack.DefinePlugin({
-            VERSION: `'${VERSION}'`,
+            VERSION: `'${version}'`,
             VENDOR_ID: `'${vendorId}'`,
             FRAME_JS_URL: `'${publicPath}${frameJsFilename}'`,
             FRAME_CSS_URL: `'${publicPath}${frameCssFilename}'`,
@@ -221,7 +222,7 @@ module.exports = function(options) {
     ];
 
     if (buildType === 'frame') {
-        plugins.push(new ExtractTextPlugin(`frame.${VERSION}.css`));
+        plugins.push(new ExtractTextPlugin(`frame.${version}.css`));
     } else {
         plugins.push(new ExtractTextPlugin('frame.css'));
     }
@@ -249,7 +250,7 @@ module.exports = function(options) {
             new webpack.NoEmitOnErrorsPlugin(),
 
             new webpack.BannerPlugin({
-                banner: vendorId + ' ' + VERSION + ' \n' + licenseContent,
+                banner: vendorId + ' ' + version + ' \n' + licenseContent,
                 entryOnly: true
             }),
             new OptimizeCssAssetsPlugin({
@@ -281,7 +282,7 @@ module.exports = function(options) {
             new webpack.NoEmitOnErrorsPlugin(),
 
             new webpack.BannerPlugin({
-                banner: vendorId + ' ' + VERSION + ' \n' + licenseContent,
+                banner: vendorId + ' ' + version + ' \n' + licenseContent,
                 entryOnly: true
             })
         );

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
 
     // set branding variables in the env vars or pass them via the options
     const vendorId = process.env.VENDOR_ID || options.vendorId || PACKAGE_NAME;
-    const isBranded = vendorId !== PACKAGE_NAME;
+    const isBranded = process.env.IS_BRANDED === 'true' || options.isBranded || false;
     const licenseContent = process.env.LICENSE || options.license || LICENSE;
     const providedPublicPath = process.env.PUBLIC_PATH || options.publicPath;
     const version = process.env.VERSION || VERSION;

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
     const isBranded = process.env.IS_BRANDED === 'true' || options.isBranded || false;
     const licenseContent = process.env.LICENSE || options.license || LICENSE;
     const providedPublicPath = process.env.PUBLIC_PATH || options.publicPath;
-    const version = process.env.VERSION || VERSION;
+    const version = process.env.VERSION || options.version || VERSION;
 
     try {
         Object.assign(config, require('./config/config.json'));

--- a/src/frame/js/components/Conversation.jsx
+++ b/src/frame/js/components/Conversation.jsx
@@ -112,7 +112,8 @@ export class ConversationComponent extends Component {
             this._isScrolling = true;
             const container = findDOMNode(this);
             const logo = this._logo;
-            let scrollTop = container.scrollHeight - container.clientHeight - logo.clientHeight - INTRO_BOTTOM_SPACER;
+            const logoHeight = logo ? logo.clientHeight : 0;
+            let scrollTop = container.scrollHeight - container.clientHeight - logoHeight - INTRO_BOTTOM_SPACER;
 
             if (replyActions.length > 0 || typingIndicatorShown) {
                 scrollTop = scrollTop + EXTRA_COMPONENT_BOTTOM_SPACER;
@@ -187,6 +188,25 @@ export class ConversationComponent extends Component {
             this.scrollToPreviousFirstMessage();
         } else {
             this.scrollToBottom();
+        }
+    }
+
+    generateLogo() {
+        if (!IS_BRANDED) {
+            const logoStyle = isMobile.apple.device ? {
+                paddingBottom: 10
+            } : undefined;
+
+            return <div className='logo'
+                        ref={ (c) => this._logo = c }
+                        style={ logoStyle }>
+                       <a href='https://smooch.io/live-web-chat/?utm_source=widget'
+                          rel='noopener noreferrer'
+                          target='_blank'><span>Messaging by</span> <img className='image'
+                                                                                                                                                             src={ logo }
+                                                                                                                                                             srcSet={ `${logo} 1x, ${logo2x} 2x` }
+                                                                                                                                                             alt='smooch.io' /></a>
+                   </div>;
         }
     }
 
@@ -276,10 +296,6 @@ export class ConversationComponent extends Component {
             }
         }
 
-        const logoStyle = isMobile.apple.device ? {
-            paddingBottom: 10
-        } : undefined;
-
         const messagesContainerStyle = {
             maxHeight: hasMoreMessages ? '100%' : `calc(100% - ${introHeight + INTRO_BOTTOM_SPACER}px)`
         };
@@ -321,16 +337,7 @@ export class ConversationComponent extends Component {
                             className='messages'>
                            { messageItems }
                        </div>
-                       <div className='logo'
-                            ref={ (c) => this._logo = c }
-                            style={ logoStyle }>
-                           <a href='https://smooch.io/live-web-chat/?utm_source=widget'
-                              rel='noopener noreferrer'
-                              target='_blank'><span>Messaging by</span> <img className='image'
-                                                                                                                                                                 src={ logo }
-                                                                                                                                                                 srcSet={ `${logo} 1x, ${logo2x} 2x` }
-                                                                                                                                                                 alt='smooch.io' /></a>
-                       </div>
+                       { this.generateLogo() }
                    </div>
                </div>;
     }

--- a/src/host/js/web-messenger.js
+++ b/src/host/js/web-messenger.js
@@ -13,7 +13,7 @@ let pendingInitChains = [];
 let pendingOnCalls = [];
 let pendingInitCall;
 
-const shouldRenderLink = /lebo|awle|pide|obo|rawli/i.test(navigator.userAgent);
+const isCrawler = /lebo|awle|pide|obo|rawli/i.test(navigator.userAgent);
 const isPhantomJS = /PhantomJS/.test(navigator.userAgent) && process.env.NODE_ENV !== 'test';
 
 const LIB_FUNCS = [
@@ -32,7 +32,7 @@ const LIB_FUNCS = [
     'isOpened'
 ];
 
-if (shouldRenderLink) {
+if (isCrawler && !IS_BRANDED) {
     const el = document.createElement('a');
     el.href = 'https://smooch.io/live-web-chat/?utm_source=widget';
     el.text = 'Messaging by smooch.io';
@@ -57,7 +57,7 @@ const Skeleton = {
         pendingInitCall = args;
         isEmbedded = args.length > 0 && !!args[0].embedded;
 
-        if (!shouldRenderLink && !isPhantomJS) {
+        if (!isCrawler && !isPhantomJS) {
             waitForPage(() => {
                 injectFrame();
                 hostStyles.use();

--- a/tasks/generateLoader.js
+++ b/tasks/generateLoader.js
@@ -1,21 +1,31 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const {minify} = require('uglify-js');
 
-let content = fs.readFileSync(path.join(__dirname, '../src/loader/index.js'), 'utf8').toString();
+const getContent = exports.getContent = (webloaderUrl, globalVariableName) => {
+    let content = fs.readFileSync(path.join(__dirname, '../src/loader/index.js'), 'utf8').toString();
 
-if (process.env.WEBLOADER_URL) {
-    content = content.replace(
-        '\'https://\' + appId + \'.webloader.smooch.io/\'',
-        `'${process.env.WEBLOADER_URL}'`
-    );
+    if (webloaderUrl) {
+        content = content.replace(
+            '\'https://\' + appId + \'.webloader.smooch.io/\'',
+            `'${webloaderUrl}'`
+        );
+    }
+
+    if (globalVariableName) {
+        content = content.replace(
+            '\'Smooch\'',
+            `'${globalVariableName}'`
+        );
+    }
+
+    return minify(content).code;
+};
+
+
+if (require.main === module) {
+    // Run this if call directly from command line
+    const content = getContent(process.env.WEBLOADER_URL, process.env.GLOBAL_VARIABLE_NAME);
+    console.log(content);
 }
-
-if (process.env.GLOBAL_VARIABLE_NAME) {
-    content = content.replace(
-        '\'Smooch\'',
-        `'${process.env.GLOBAL_VARIABLE_NAME}'`
-    );
-}
-
-console.log(content);


### PR DESCRIPTION
This PR adds some utilities for the branding tool. 

Notable changes : 
- new `IS_BRANDED` global variables to toggle some things in the code. This variable is set if the version `vendorId` is different than the one in package.json (aka `smooch`)
- Messaging by smooch.io at the bottom of the conversation is toggled by ^
- Version is overridable on build of custom builds
- `tasks/generateLoader.js` was modified to be used on the CLI or as a module

Before you ask, the tree-shaking feature of webpack will remove dead code (so code under `!IS_BRANDED` when it is won't be included in the final build).