### PR TITLE
Fix faye implementation in git fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "deep-equal": "1.0.1",
-    "faye": "1.1.2",
+    "faye": "jugarrit/faye#temp-smooch-fix",
     "ismobilejs": "0.3.9",
     "lodash.bindall": "4.4.0",
     "lodash.debounce": "4.0.3",
@@ -148,8 +148,5 @@
     "babel-runtime": ">=6.9.0 <7.0",
     "react": "15.x.x",
     "react-dom": "15.x.x"
-  },
-  "browser": {
-    "faye": "faye/browser/faye-browser"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "deep-equal": "1.0.1",
-    "faye": "jugarrit/faye#temp-smooch-fix",
+    "faye": "smooch/faye#temp-smooch-fix",
     "ismobilejs": "0.3.9",
     "lodash.bindall": "4.4.0",
     "lodash.debounce": "4.0.3",


### PR DESCRIPTION
This fixes a problem in the faye lib we're using where it was failing to correctly fall back to long polling if websockets did not work.

See https://github.com/faye/faye/pull/482 + https://github.com/faye/faye/pull/483 for details on the fixes.

The https://github.com/jugarrit/faye/tree/temp-smooch-fix branch contains both fixes and will be used in the meantime.