### PR TITLE
Fix message spacing for appMakers

### DIFF
--- a/src/frame/js/components/Message.jsx
+++ b/src/frame/js/components/Message.jsx
@@ -43,7 +43,7 @@ class MessageComponent extends Component {
     }
 
     _restyleBubble() {
-        const bubble = findDOMNode(this.refs.messageContent);
+        const bubble = this._messageContent;
         if (bubble) {
             const messageElement = bubble.firstChild;
             const messageProperties = getElementProperties(messageElement);
@@ -84,7 +84,7 @@ class MessageComponent extends Component {
         }
 
         const avatarClass = hasImage ? ['msg-avatar', 'msg-avatar-img'] : ['msg-avatar'];
-        const avatarPlaceHolder = isAppUser ? null : (<div className='msg-avatar-placeholder' />);
+        const avatarPlaceHolder = isAppUser ? null : <div className='msg-avatar-placeholder' />;
         const containerClasses = ['msg'];
 
         if (hasImage || actions.length > 0) {
@@ -197,11 +197,11 @@ class MessageComponent extends Component {
 
         return <div className={ rowClass.join(' ') }>
                    { !isAppUser && firstInGroup ? fromName : null }
-                   { lastInGroup ? avatar : avatarPlaceHolder }
                    <div className='msg-wrapper'>
+                       { lastInGroup ? avatar : avatarPlaceHolder }
                        <div className={ containerClasses.join(' ') }
                             style={ style }
-                            ref='messageContent'
+                            ref={ (c) => this._messageContent = c }
                             onClick={ this.onMessageClick.bind(this) }>
                            { imagePart ? imagePart : null }
                            { textPart ? textPart : null }

--- a/src/frame/stylesheets/conversation.less
+++ b/src/frame/stylesheets/conversation.less
@@ -138,6 +138,8 @@
         .msg-wrapper {
             max-width: 100%;
             position: relative;
+            display: flex;
+            flex-direction: row;
 
             .msg, .msg-image {
                 font-size: @font-size-base;
@@ -247,8 +249,7 @@
         }
         &.left-row {
             .msg-wrapper {
-                display: inline-block;
-
+                align-items: flex-end;
                 .msg, .msg-image {
                     background-color: @light-grey;
                     color: @darker-grey;
@@ -266,24 +267,27 @@
             }
         }
         &.right-row {
-            .msg, .msg-image {
-                background-color: @blue;
-                float: right;
-                color: white;
-                max-width: 204px;
-
-                &:after {
-                    left: 100%;
-                    border-color: rgba(0, 174, 255, 0);
-                    border-left-color: inherit;
-                }
-                a.link, a.link:visited {
+            .msg-wrapper {
+                flex-direction: row-reverse;
+                .msg, .msg-image {
+                    background-color: @blue;
+                    float: right;
                     color: white;
-                }
-            }
+                    max-width: 204px;
 
-            .msg-image {
-                background-color: transparent;
+                    &:after {
+                        left: 100%;
+                        border-color: rgba(0, 174, 255, 0);
+                        border-left-color: inherit;
+                    }
+                    a.link, a.link:visited {
+                        color: white;
+                    }
+                }
+
+                .msg-image {
+                    background-color: transparent;
+                }
             }
         }
         &:last-child {
@@ -376,7 +380,7 @@
 
 .msg-avatar {
     width: 31px;
-    height: auto;
+    height: 31px;
     border-radius: 50%;
     margin-right: 5px;
     display: inline-block;


### PR DESCRIPTION
This ^.

`display: inline-block` was messing things up so I changed to `flex` and changed the way things are ordered.

![image](https://user-images.githubusercontent.com/781844/30289057-dae21d16-96f8-11e7-8d2e-6e7d4d21dde3.png)
