### PR TITLE
Enable easy custom builds for forkers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "globals": {
         "VERSION": true,
         "VENDOR_ID": true,
+        "GLOBAL_VAR_NAME": true,
         "FRAME_JS_URL": true,
         "FRAME_CSS_URL": true,
         "SENTRY_DSN": true,

--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ In one console, run `npm run dev` to start the web server.
 
 Then, go to `http://localhost:8282` to test the normal widget or `http://localhost:8282/embedded` for the embedded one.
 
+## How to generate a custom build
+1. Make changes to the code.
+2. Run `VERSION=X.Y.Z PUBLIC_PATH=https://your.cdn.com npm run build` (replace `https://your.cdn.com` with the address where the files will be hosted and also replace `X.Y.Z` with the version number you want).
+3. Take everything in `dist/` and host it at the address above.
+4. Make sure your server allow cross-origin requests to allow loading the library.
+5. Include the library in the `head` section of your page with a script tag (`<script src="https://your.cdn.com/smooch.X.Y.Z.min.js"></script>`). The script loader is not necessary when using a custom build.
+
 ## Acknowledgements
 
 https://github.com/lipis/flag-icon-css

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -9,6 +9,10 @@ const urljoin = require('urljoin');
 
 const rulesByExtension = require('./webpack/lib/rulesByExtension');
 
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 // Possible options:
 // buildType : possible values ['npm', 'host', 'frame', 'dev', 'test']
 //  - npm : build in prevision of the npm release
@@ -34,6 +38,7 @@ module.exports = function(options) {
     const licenseContent = process.env.LICENSE || options.license || LICENSE;
     const providedPublicPath = process.env.PUBLIC_PATH || options.publicPath;
     const version = process.env.VERSION || options.version || VERSION;
+    const globalVarName = capitalizeFirstLetter(vendorId);
 
     let entry;
 
@@ -202,6 +207,7 @@ module.exports = function(options) {
         new webpack.DefinePlugin({
             VERSION: `'${version}'`,
             VENDOR_ID: `'${vendorId}'`,
+            GLOBAL_VAR_NAME: `'${globalVarName}'`,
             FRAME_JS_URL: `'${urljoin(publicPath, frameJsFilename)}'`,
             FRAME_CSS_URL: `'${urljoin(publicPath, frameCssFilename)}'`,
             SENTRY_DSN: options.sentryDsn ? `'${options.sentryDsn}'` : 'undefined',

--- a/src/frame/js/components/ReplyActions.jsx
+++ b/src/frame/js/components/ReplyActions.jsx
@@ -11,6 +11,7 @@ import LocationIcon from './LocationIcon';
 
 export class ReplyActionsComponent extends Component {
     static propTypes = {
+        dispatch: PropTypes.func.isRequired,
         accentColor: PropTypes.string,
         isAccentColorDark: PropTypes.bool,
         choices: PropTypes.array.isRequired,

--- a/src/host/js/index.js
+++ b/src/host/js/index.js
@@ -2,6 +2,7 @@ import WebMessenger from './web-messenger';
 
 if (window.__onWebMessengerHostReady__) {
     window.__onWebMessengerHostReady__(WebMessenger);
-} else {
-    console.error('Script loader not found. Please check out the setup instructions.');
+} else if (GLOBAL_VAR_NAME) {
+    // Script loader wasn't found, host bundle is being used on its own.
+    global[GLOBAL_VAR_NAME] = WebMessenger;
 }


### PR DESCRIPTION
This PR allows the host part to be used without a script loader so that custom builds made by people who forked the lib can work. I also fixed some linting issues here and there and added a section in the README to generate the build.